### PR TITLE
[지토] step2-1 체스판 생성

### DIFF
--- a/chess/.idea/gradle.xml
+++ b/chess/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/chess/build.gradle
+++ b/chess/build.gradle
@@ -19,3 +19,7 @@ dependencies {
 test {
     useJUnitPlatform()
 }
+
+tasks.withType(JavaCompile) {
+    options.encoding = 'UTF-8'
+}

--- a/chess/src/main/java/org/example/Pawn.java
+++ b/chess/src/main/java/org/example/Pawn.java
@@ -3,8 +3,14 @@ package org.example;
 public class Pawn {
     String color;
 
+    public static final String BLACK = "black";
+    public static final String WHITE = "white";
+
     public Pawn(String color) {
         this.color=color;
+    }
+    public Pawn(){
+        this.color="white";
     }
 
     public String getColor() {

--- a/chess/src/test/java/PawnTest.java
+++ b/chess/src/test/java/PawnTest.java
@@ -3,8 +3,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class PawnTest {
+
 
     @Test
     @DisplayName("흰색 폰이 생성되어야 한다")
@@ -27,6 +29,12 @@ public class PawnTest {
     public void verifyPawn(final String color){
         Pawn pawn = new Pawn(color);
         assertThat(pawn.getColor()).isEqualTo(color);
+    }
+
+    @Test
+    public void create_기본생성자() throws Exception {
+        Pawn pawn = new Pawn();
+        assertEquals("white", pawn.getColor());
     }
 
 }


### PR DESCRIPTION
## 구현 내용
step2-1 체스판 생성
2-1. Pawn 클래스 변경
(1) 매개 변수 없는 생성자
(2) 색깔을 상수로

## 고민 사항
PawnTest 실행 시 한글깨짐 현상이 발생하였다. 
File -> File Properties -> File Encoding -> More -> UTF-8클릭, 
Help -> Edit Custom Vm Options 클릭 -> idea64.exe.vmoptions파일로 이동하여 -Dfile.encoding=UTF-8
-Dconsole.encoding=UTF-8

추가해주니까 문제가 해결되었다.

## 기타
