### PR TITLE
[Glad] Step 2 - 5 기물 위치 부여 및 점수계산

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,52 @@
   - 여러 `Piece`를 생성하고 `color`, `name`이 잘 들어갔는지 확인
 - [ ] `Board` 클래스 변경
   - `initialize()` 메소드를 이용해 모든 `Piece`를 초기화
+
+## Step 2 - 5
+
+### 기물 위치 부여 및 점수계산
+
+- [ ] `Piece` 클래스 enum 추가
+  - `Color` enum 추가
+    - `WHITE`, `BLACK`, `NOCOLOR` 추가
+  - `Type` enum 추가
+    - `PAWN`, `ROOK`, `KNIGHT`, `BISHOP`, `QUEEN`, `KING`, `NO_PIECE` 추가
+    - 식별 문자 함께 관리
+    - 식별 문자는 **소문자**로만 관리
+  - 기존 **상수 값 제거**
+- [ ] `Piece` 클래스 `enum` 이용한 팩토리 메소드 리펙토링
+  - `REPRESANTATION` 을 `Type` enum으로 변경
+  - `createWhite(type: Type): Piece`, `createBlack(type: Type): Piece` 메소드 통합 관리
+- [ ] `Board` 클래스 변경
+  - `initialize()` 메소드에서 빈 공간도 `Piece.createBlank()`로 초기화
+  - `Rank(row)` 를 기반으로 `List<Piece>` 관리 로직 수정
+- [ ] 기물과 색에 해당하는 **기물의 개수**를 반환
+  - `Board` 클래스에 `countPieceByColorAndType(color: Color, type: Type): int` 메소드 추가
+  - _ex_
+    - 검은 폰의 개수: `countPieceByColorAndType(Color.BLACK, Type.PAWN): int`
+- [ ] 주어진 위치의 기물 조회 로직 작성
+  - `Board` 클래스에 `findPieceByPosition(position : String): Piece` 메소드 추가
+  - `row`는 `1~8`, `column`은 `a~h`로 관리
+  - 좌측 상단이 `(8, a)`, 우측 하단이 `(1, h)`로 관리
+  - _ex_
+    - `findPieceByPosition("a1"): Piece`
+- [ ] 임의의 기물을 **체스판 위에 추가**
+  - `Board` 클래스에 `move(to : String, piece : Piece): void` 메소드 추가
+  - test 하기 위해서 **빈 체스판** 생성 후 `move` 메소드로 기물 추가
+  - 기존 `List<Piece>` 에서 제거 후 새로운 Piece 로 변경하는 경우 `set()` 메소드 사용
+- [ ] **점수 계산** 로직 추가
+  - `Board` 클래스에 `calculatePoint(color: Color): double` 메소드 추가
+  - 각 기물의 점수는 다음과 같음
+    - 폰: **1.0**
+    - 룩: **5.0**
+    - 나이트: **2.5**
+    - 비숍: **3.0**
+    - 퀸: **9.0**
+    - 킹: **0.0**
+  - _ex_
+    - 흰 폰의 점수: `calculateScore(Color.WHITE): double`
+  - 한 번에 **한 쪽의 점수만** 계산
+  - 검은 색과 흰 색 기물을 구분해서 **점수가 높은 순서로 정렬**한다
+  - 각 색에 해당하는 모든 기물을 **`Collection`**에 담아서 **정렬**한다
+- [ ] 리펙토링
+  - **인터페이스**를 이용해 추출

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -61,10 +61,10 @@ public class Board {
 
     private void placePiecesOnBoard() {
         for (int i = 0; i < BOARD_SIZE; i++) {
-            board[BLACK_MAIN_ROW][i] = blackPieces.get(i).getRepresentation();
-            board[BLACK_PAWN_ROW][i] = blackPieces.get(i + BOARD_SIZE).getRepresentation();
-            board[WHITE_PAWN_ROW][i] = whitePieces.get(i).getRepresentation();
-            board[WHITE_MAIN_ROW][i] = whitePieces.get(i + BOARD_SIZE).getRepresentation();
+            board[BLACK_MAIN_ROW][i] = blackPieces.get(i).getType().getBlackType();
+            board[BLACK_PAWN_ROW][i] = blackPieces.get(i + BOARD_SIZE).getType().getBlackType();
+            board[WHITE_PAWN_ROW][i] = whitePieces.get(i).getType().getWhiteType();
+            board[WHITE_MAIN_ROW][i] = whitePieces.get(i + BOARD_SIZE).getType().getWhiteType();
         }
     }
 

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -86,10 +86,9 @@ public class Board {
     }
 
     public void move(String position, Piece piece) {
-        int col = position.charAt(0) - 'a';
-        int rank = position.charAt(1) - '1';
+        Position pos = Position.of(position);
 
-        board.get(BOARD_SIZE - rank - 1).getPieces().set(col, piece);
+        board.get(pos.y()).getPieces().set(pos.x(), piece);
     }
 
     public int pieceCount() {
@@ -107,11 +106,10 @@ public class Board {
         return whitePieces.get(index);
     }
 
-    public Piece findPiece(String pos) {
-        int col = pos.charAt(0) - 'a';
-        int rank = pos.charAt(1) - '1';
+    public Piece findPiece(String position) {
+        Position pos = Position.of(position);
 
-        return board.get(BOARD_SIZE - rank - 1).getPieces().get(col);
+        return board.get(pos.y()).getPieces().get(pos.x());
     }
 
     public String getPawnsResultWith(int row) {

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -33,20 +33,20 @@ public class Board {
 
     private void setupPieces() {
         blackPieces.addAll(List.of(
-                Piece.createBlackRook(), Piece.createBlackKnight(), Piece.createBlackBishop(),
-                Piece.createBlackQueen(), Piece.createBlackKing(), Piece.createBlackBishop(),
-                Piece.createBlackKnight(), Piece.createBlackRook()
+                Piece.createBlack(Piece.Type.ROOK), Piece.createBlack(Piece.Type.KNIGHT), Piece.createBlack(Piece.Type.BISHOP),
+                Piece.createBlack(Piece.Type.QUEEN), Piece.createBlack(Piece.Type.KING), Piece.createBlack(Piece.Type.BISHOP),
+                Piece.createBlack(Piece.Type.KNIGHT), Piece.createBlack(Piece.Type.ROOK)
         ));
 
         for (int i = 0; i < BOARD_SIZE; i++) {
-            whitePieces.add(Piece.createWhitePawn());
-            blackPieces.add(Piece.createBlackPawn());
+            whitePieces.add(Piece.createWhite(Piece.Type.PAWN));
+            blackPieces.add(Piece.createBlack(Piece.Type.PAWN));
         }
 
         whitePieces.addAll(List.of(
-                Piece.createWhiteRook(), Piece.createWhiteKnight(), Piece.createWhiteBishop(),
-                Piece.createWhiteQueen(), Piece.createWhiteKing(), Piece.createWhiteBishop(),
-                Piece.createWhiteKnight(), Piece.createWhiteRook()
+                Piece.createWhite(Piece.Type.ROOK), Piece.createWhite(Piece.Type.KNIGHT), Piece.createWhite(Piece.Type.BISHOP),
+                Piece.createWhite(Piece.Type.QUEEN), Piece.createWhite(Piece.Type.KING), Piece.createWhite(Piece.Type.BISHOP),
+                Piece.createWhite(Piece.Type.KNIGHT), Piece.createWhite(Piece.Type.ROOK)
         ));
 
     }

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -4,6 +4,7 @@ import org.chess.domain.pieces.Piece;
 import org.chess.utils.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 public class Board {
@@ -122,6 +123,28 @@ public class Board {
                 .filter(piece -> piece.getColor() == color)
                 .mapToDouble(Piece::getPoint)
                 .sum();
+    }
+
+    public List<Piece> sortPiecesByAscending(Piece.Color color) {
+        List<Piece> sortedPieces = new ArrayList<>();
+        board.stream()
+                .flatMap(rank -> rank.getPieces().stream())
+                .filter(piece -> piece.getColor() == color)
+                .sorted(Comparator.comparingDouble(Piece::getPoint))
+                .forEach(sortedPieces::add);
+
+        return sortedPieces;
+    }
+
+    public List<Piece> sortPiecesByDescending(Piece.Color color) {
+        List<Piece> sortedPieces = new ArrayList<>();
+        board.stream()
+                .flatMap(rank -> rank.getPieces().stream())
+                .filter(piece -> piece.getColor() == color)
+                .sorted((p1, p2) -> Double.compare(p2.getPoint(), p1.getPoint()))
+                .forEach(sortedPieces::add);
+
+        return sortedPieces;
     }
 
 }

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -89,6 +89,13 @@ public class Board {
         return whitePieces.size() + blackPieces.size();
     }
 
+    public int countPieces(Piece.Color color, Piece.Type type) {
+        return (int) board.stream()
+                .flatMap(rank -> rank.getPieces().stream())
+                .filter(piece -> piece.getColor() == color && piece.getType() == type)
+                .count();
+    }
+
     public Piece findPawn(int index) {
         return whitePieces.get(index);
     }

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -51,13 +51,14 @@ public class Board {
 
     }
 
+    // @todo: 빈 값 하나 바꾸면 모든 Rank 줄이 바뀌는 문제 해결
     public void initializeEmptyBoard() {
-        List<Piece> emptyPieces = new ArrayList<>();
         for (int i = 0; i < BOARD_SIZE; i++) {
-            emptyPieces.add(Piece.createBlankPiece());
-        }
+            List<Piece> emptyPieces = new ArrayList<>();
+            for (int j = 0; j < BOARD_SIZE; j++) {
+                emptyPieces.add(Piece.createBlankPiece());
+            }
 
-        for (int i = 0; i < BOARD_SIZE; i++) {
             board.add(Rank.of(emptyPieces));
         }
     }

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -27,7 +27,7 @@ public class Board {
 
     public void initialize() {
         setupPieces();
-        initializeBoard();
+        initializeEmptyBoard();
         placePiecesOnBoard();
     }
 
@@ -51,7 +51,7 @@ public class Board {
 
     }
 
-    private void initializeBoard() {
+    public void initializeEmptyBoard() {
         List<Piece> emptyPieces = new ArrayList<>();
         for (int i = 0; i < BOARD_SIZE; i++) {
             emptyPieces.add(Piece.createBlankPiece());
@@ -63,10 +63,10 @@ public class Board {
     }
 
     private void placePiecesOnBoard() {
-        board.set(6, Rank.of(whitePieces.subList(0, 8)));
-        board.set(7, Rank.of(whitePieces.subList(8, 16)));
-        board.set(0, Rank.of(blackPieces.subList(0, 8)));
-        board.set(1, Rank.of(blackPieces.subList(8, 16)));
+        board.set(WHITE_PAWN_ROW, Rank.of(whitePieces.subList(0, 8)));
+        board.set(WHITE_MAIN_ROW, Rank.of(whitePieces.subList(8, 16)));
+        board.set(BLACK_MAIN_ROW, Rank.of(blackPieces.subList(0, 8)));
+        board.set(BLACK_PAWN_ROW, Rank.of(blackPieces.subList(8, 16)));
     }
 
     public void print() {

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -51,7 +51,6 @@ public class Board {
 
     }
 
-    // @todo: 빈 값 하나 바꾸면 모든 Rank 줄이 바뀌는 문제 해결
     public void initializeEmptyBoard() {
         for (int i = 0; i < BOARD_SIZE; i++) {
             List<Piece> emptyPieces = new ArrayList<>();

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -34,7 +34,7 @@ public class Board {
     private void setupPieces() {
         blackPieces.addAll(List.of(
                 Piece.createBlackRook(), Piece.createBlackKnight(), Piece.createBlackBishop(),
-                Piece.createBlackQuenn(), Piece.createBlackKing(), Piece.createBlackBishop(),
+                Piece.createBlackQueen(), Piece.createBlackKing(), Piece.createBlackBishop(),
                 Piece.createBlackKnight(), Piece.createBlackRook()
         ));
 
@@ -45,7 +45,7 @@ public class Board {
 
         whitePieces.addAll(List.of(
                 Piece.createWhiteRook(), Piece.createWhiteKnight(), Piece.createWhiteBishop(),
-                Piece.createWhiteQuenn(), Piece.createWhiteKing(), Piece.createWhiteBishop(),
+                Piece.createWhiteQueen(), Piece.createWhiteKing(), Piece.createWhiteBishop(),
                 Piece.createWhiteKnight(), Piece.createWhiteRook()
         ));
 

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -15,12 +15,12 @@ public class Board {
     private static final int BLACK_MAIN_ROW = 0;
     private static final int BLACK_PAWN_ROW = 1;
 
-    private final char[][] board;
+    private final List<Rank> board;
     private final List<Piece> whitePieces;
     private final List<Piece> blackPieces;
 
     public Board() {
-        this.board = new char[BOARD_SIZE][BOARD_SIZE];
+        this.board = new ArrayList<>();
         this.whitePieces = new ArrayList<>();
         this.blackPieces = new ArrayList<>();
     }
@@ -52,20 +52,21 @@ public class Board {
     }
 
     private void initializeBoard() {
+        List<Piece> emptyPieces = new ArrayList<>();
         for (int i = 0; i < BOARD_SIZE; i++) {
-            for (int j = 0; j < BOARD_SIZE; j++) {
-                board[i][j] = EMPTY;
-            }
+            emptyPieces.add(Piece.createBlankPiece());
+        }
+
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            board.add(Rank.of(emptyPieces));
         }
     }
 
     private void placePiecesOnBoard() {
-        for (int i = 0; i < BOARD_SIZE; i++) {
-            board[BLACK_MAIN_ROW][i] = blackPieces.get(i).getType().getBlackType();
-            board[BLACK_PAWN_ROW][i] = blackPieces.get(i + BOARD_SIZE).getType().getBlackType();
-            board[WHITE_PAWN_ROW][i] = whitePieces.get(i).getType().getWhiteType();
-            board[WHITE_MAIN_ROW][i] = whitePieces.get(i + BOARD_SIZE).getType().getWhiteType();
-        }
+        board.set(6, Rank.of(whitePieces.subList(0, 8)));
+        board.set(7, Rank.of(whitePieces.subList(8, 16)));
+        board.set(0, Rank.of(blackPieces.subList(0, 8)));
+        board.set(1, Rank.of(blackPieces.subList(8, 16)));
     }
 
     public void print() {
@@ -74,8 +75,8 @@ public class Board {
 
     public String showBoard() {
         StringBuilder sb = new StringBuilder();
-        for (char[] row : board) {
-            sb.append(row).append(StringUtils.NEWLINE);
+        for (Rank rank : board) {
+            sb.append(rank).append(StringUtils.NEWLINE);
         }
         return sb.toString();
     }
@@ -93,7 +94,7 @@ public class Board {
     }
 
     public String getPawnsResultWith(int row) {
-        return new String(board[row]);
+        return board.get(row).toString();
     }
 
 }

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -116,4 +116,12 @@ public class Board {
         return board.get(row).toString();
     }
 
+    public double calculatePoint(Piece.Color color) {
+        return board.stream()
+                .flatMap(rank -> rank.getPieces().stream())
+                .filter(piece -> piece.getColor() == color)
+                .mapToDouble(Piece::getPoint)
+                .sum();
+    }
+
 }

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -85,6 +85,13 @@ public class Board {
         whitePieces.add(piece);
     }
 
+    public void move(String position, Piece piece) {
+        int col = position.charAt(0) - 'a';
+        int rank = position.charAt(1) - '1';
+
+        board.get(BOARD_SIZE - rank - 1).getPieces().set(col, piece);
+    }
+
     public int pieceCount() {
         return whitePieces.size() + blackPieces.size();
     }

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -100,6 +100,13 @@ public class Board {
         return whitePieces.get(index);
     }
 
+    public Piece findPiece(String pos) {
+        int col = pos.charAt(0) - 'a';
+        int rank = pos.charAt(1) - '1';
+
+        return board.get(BOARD_SIZE - rank - 1).getPieces().get(col);
+    }
+
     public String getPawnsResultWith(int row) {
         return board.get(row).toString();
     }

--- a/app/src/main/java/org/chess/domain/board/Board.java
+++ b/app/src/main/java/org/chess/domain/board/Board.java
@@ -6,6 +6,8 @@ import org.chess.utils.StringUtils;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class Board {
 
@@ -54,11 +56,9 @@ public class Board {
 
     public void initializeEmptyBoard() {
         for (int i = 0; i < BOARD_SIZE; i++) {
-            List<Piece> emptyPieces = new ArrayList<>();
-            for (int j = 0; j < BOARD_SIZE; j++) {
-                emptyPieces.add(Piece.createBlankPiece());
-            }
-
+            List<Piece> emptyPieces = IntStream.range(0, BOARD_SIZE)
+                    .mapToObj(j -> Piece.createBlankPiece())
+                    .collect(Collectors.toList());
             board.add(Rank.of(emptyPieces));
         }
     }
@@ -126,25 +126,19 @@ public class Board {
     }
 
     public List<Piece> sortPiecesByAscending(Piece.Color color) {
-        List<Piece> sortedPieces = new ArrayList<>();
-        board.stream()
+        return board.stream()
                 .flatMap(rank -> rank.getPieces().stream())
                 .filter(piece -> piece.getColor() == color)
                 .sorted(Comparator.comparingDouble(Piece::getPoint))
-                .forEach(sortedPieces::add);
-
-        return sortedPieces;
+                .collect(Collectors.toList());
     }
 
     public List<Piece> sortPiecesByDescending(Piece.Color color) {
-        List<Piece> sortedPieces = new ArrayList<>();
-        board.stream()
+        return board.stream()
                 .flatMap(rank -> rank.getPieces().stream())
                 .filter(piece -> piece.getColor() == color)
-                .sorted((p1, p2) -> Double.compare(p2.getPoint(), p1.getPoint()))
-                .forEach(sortedPieces::add);
-
-        return sortedPieces;
+                .sorted(Comparator.comparingDouble(Piece::getPoint).reversed())
+                .collect(Collectors.toList());
     }
 
 }

--- a/app/src/main/java/org/chess/domain/board/Position.java
+++ b/app/src/main/java/org/chess/domain/board/Position.java
@@ -1,0 +1,29 @@
+package org.chess.domain.board;
+
+public class Position {
+
+    private static final int BOARD_SIZE = 8;
+
+    private final int y;
+    private final int x;
+
+    private Position(int y, int x) {
+        this.y = y;
+        this.x = x;
+    }
+
+    public static Position of(String pos) {
+        int x = pos.charAt(0) - 'a';
+        int y = pos.charAt(1) - '1';
+        return new Position(y, x);
+    }
+
+    public int y() {
+        return BOARD_SIZE - y - 1;
+    }
+
+    public int x() {
+        return x;
+    }
+
+}

--- a/app/src/main/java/org/chess/domain/board/Rank.java
+++ b/app/src/main/java/org/chess/domain/board/Rank.java
@@ -1,0 +1,23 @@
+package org.chess.domain.board;
+
+import org.chess.domain.pieces.Piece;
+
+import java.util.List;
+
+public class Rank {
+
+    private final List<Piece> pieces;
+
+    private Rank(List<Piece> pieces) {
+        this.pieces = pieces;
+    }
+
+    public static Rank of(List<Piece> pieces) {
+        return new Rank(pieces);
+    }
+
+    public List<Piece> getPieces() {
+        return pieces;
+    }
+
+}

--- a/app/src/main/java/org/chess/domain/board/Rank.java
+++ b/app/src/main/java/org/chess/domain/board/Rank.java
@@ -20,4 +20,13 @@ public class Rank {
         return pieces;
     }
 
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        for (Piece piece : pieces) {
+            sb.append(piece.getColor() == Piece.Color.WHITE ? piece.getType().getWhiteType() : piece.getType().getBlackType());
+        }
+        return sb.toString();
+    }
+
 }

--- a/app/src/main/java/org/chess/domain/pieces/Piece.java
+++ b/app/src/main/java/org/chess/domain/pieces/Piece.java
@@ -8,6 +8,7 @@ public class Piece {
     public static final String ROOK_NAME = "rook";
     public static final String BISHOP_NAME = "bishop";
     public static final String KNIGHT_NAME = "knight";
+    public static final String BLANK_NAME = "blank";
 
     public enum Color {
         WHITE("white"), BLACK("black"), NOCOLOR("null");
@@ -107,6 +108,10 @@ public class Piece {
 
     public static Piece createBlackKnight() {
         return new Piece(KNIGHT_NAME, Color.BLACK, Type.KNIGHT);
+    }
+
+    public static Piece createBlankPiece() {
+        return new Piece(BLANK_NAME, Color.NOCOLOR, Type.NO_PIECE);
     }
 
     public boolean isWhite() {

--- a/app/src/main/java/org/chess/domain/pieces/Piece.java
+++ b/app/src/main/java/org/chess/domain/pieces/Piece.java
@@ -19,22 +19,28 @@ public class Piece {
     }
 
     public enum Type {
-        PAWN('p'),
-        ROOK('r'),
-        KNIGHT('n'),
-        BISHOP('b'),
-        QUEEN('q'),
-        KING('k'),
-        NO_PIECE('.');
+        PAWN('p', 1.0),
+        ROOK('r', 5.0),
+        KNIGHT('n', 2.5),
+        BISHOP('b', 3.0),
+        QUEEN('q', 9.0),
+        KING('k', 0.0),
+        NO_PIECE('.', 0.0);
 
         private final char representation;
+        private final double defaultPoint;
 
-        Type(char representation) {
+        Type(char representation, double defaultPoint) {
             this.representation = representation;
+            this.defaultPoint = defaultPoint;
         }
 
         public char getType() {
             return representation;
+        }
+
+        public double getDefaultPoint() {
+            return defaultPoint;
         }
 
         public char getBlackType() {
@@ -80,6 +86,10 @@ public class Piece {
 
     public Type getType() {
         return representation;
+    }
+
+    public double getPoint() {
+        return representation.defaultPoint;
     }
 
     @Override

--- a/app/src/main/java/org/chess/domain/pieces/Piece.java
+++ b/app/src/main/java/org/chess/domain/pieces/Piece.java
@@ -62,52 +62,12 @@ public class Piece {
         this.representation = representation;
     }
 
-    public static Piece createWhitePawn() {
-        return new Piece(PAWN_NAME, Color.WHITE, Type.PAWN);
+    public static Piece createWhite(Piece.Type type) {
+        return new Piece(type.name(), Color.WHITE, type);
     }
 
-    public static Piece createBlackPawn() {
-        return new Piece(PAWN_NAME, Color.BLACK, Type.PAWN);
-    }
-
-    public static Piece createWhiteQueen() {
-        return new Piece(QUEEN_NAME, Color.WHITE, Type.QUEEN);
-    }
-
-    public static Piece createBlackQueen() {
-        return new Piece(QUEEN_NAME, Color.BLACK, Type.QUEEN);
-    }
-
-    public static Piece createWhiteKing() {
-        return new Piece(KING_NAME, Color.WHITE, Type.KING);
-    }
-
-    public static Piece createBlackKing() {
-        return new Piece(KING_NAME, Color.BLACK, Type.KING);
-    }
-
-    public static Piece createWhiteRook() {
-        return new Piece(ROOK_NAME, Color.WHITE, Type.ROOK);
-    }
-
-    public static Piece createBlackRook() {
-        return new Piece(ROOK_NAME, Color.BLACK, Type.ROOK);
-    }
-
-    public static Piece createWhiteBishop() {
-        return new Piece(BISHOP_NAME, Color.WHITE, Type.BISHOP);
-    }
-
-    public static Piece createBlackBishop() {
-        return new Piece(BISHOP_NAME, Color.BLACK, Type.BISHOP);
-    }
-
-    public static Piece createWhiteKnight() {
-        return new Piece(KNIGHT_NAME, Color.WHITE, Type.KNIGHT);
-    }
-
-    public static Piece createBlackKnight() {
-        return new Piece(KNIGHT_NAME, Color.BLACK, Type.KNIGHT);
+    public static Piece createBlack(Piece.Type type) {
+        return new Piece(type.name(), Color.BLACK, type);
     }
 
     public static Piece createBlankPiece() {

--- a/app/src/main/java/org/chess/domain/pieces/Piece.java
+++ b/app/src/main/java/org/chess/domain/pieces/Piece.java
@@ -82,4 +82,17 @@ public class Piece {
         return representation;
     }
 
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        Piece piece = (Piece) obj;
+        return color.equals(piece.color) && representation == piece.representation;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(color, representation);
+    }
+
 }

--- a/app/src/main/java/org/chess/domain/pieces/Piece.java
+++ b/app/src/main/java/org/chess/domain/pieces/Piece.java
@@ -2,14 +2,6 @@ package org.chess.domain.pieces;
 
 public class Piece {
 
-    public static final String PAWN_NAME = "pawn";
-    public static final String QUEEN_NAME = "queen";
-    public static final String KING_NAME = "king";
-    public static final String ROOK_NAME = "rook";
-    public static final String BISHOP_NAME = "bishop";
-    public static final String KNIGHT_NAME = "knight";
-    public static final String BLANK_NAME = "blank";
-
     public enum Color {
         WHITE("white"), BLACK("black"), NOCOLOR("null");
 
@@ -52,26 +44,24 @@ public class Piece {
         }
     }
 
-    private final String name;
     private final Color color;
     private final Type representation;
 
-    private Piece(String name, Color color, Type representation) {
-        this.name = name;
+    private Piece(Color color, Type representation) {
         this.color = color;
         this.representation = representation;
     }
 
     public static Piece createWhite(Piece.Type type) {
-        return new Piece(type.name(), Color.WHITE, type);
+        return new Piece(Color.WHITE, type);
     }
 
     public static Piece createBlack(Piece.Type type) {
-        return new Piece(type.name(), Color.BLACK, type);
+        return new Piece(Color.BLACK, type);
     }
 
     public static Piece createBlankPiece() {
-        return new Piece(BLANK_NAME, Color.NOCOLOR, Type.NO_PIECE);
+        return new Piece(Color.NOCOLOR, Type.NO_PIECE);
     }
 
     public boolean isWhite() {
@@ -80,10 +70,6 @@ public class Piece {
 
     public boolean isBlack() {
         return color.equals(Color.BLACK);
-    }
-
-    public String getName() {
-        return name;
     }
 
     public Color getColor() {

--- a/app/src/main/java/org/chess/domain/pieces/Piece.java
+++ b/app/src/main/java/org/chess/domain/pieces/Piece.java
@@ -1,5 +1,7 @@
 package org.chess.domain.pieces;
 
+import java.util.Objects;
+
 public class Piece {
 
     public enum Color {

--- a/app/src/main/java/org/chess/domain/pieces/Piece.java
+++ b/app/src/main/java/org/chess/domain/pieces/Piece.java
@@ -2,9 +2,6 @@ package org.chess.domain.pieces;
 
 public class Piece {
 
-    public static final String WHITE_COLOR = "white";
-    public static final String BLACK_COLOR = "black";
-
     public static final String PAWN_NAME = "pawn";
     public static final String QUEEN_NAME = "queen";
     public static final String KING_NAME = "king";
@@ -12,94 +9,123 @@ public class Piece {
     public static final String BISHOP_NAME = "bishop";
     public static final String KNIGHT_NAME = "knight";
 
-    public static final char WHITE_PAWN_REPRESENTATION = 'p';
-    public static final char BLACK_PAWN_REPRESENTATION = 'P';
-    public static final char WHITE_QUEEN_REPRESENTATION = 'q';
-    public static final char BLACK_QUEEN_REPRESENTATION = 'Q';
-    public static final char WHITE_KING_REPRESENTATION = 'k';
-    public static final char BLACK_KING_REPRESENTATION = 'K';
-    public static final char WHITE_ROOK_REPRESENTATION = 'r';
-    public static final char BLACK_ROOK_REPRESENTATION = 'R';
-    public static final char WHITE_BISHOP_REPRESENTATION = 'b';
-    public static final char BLACK_BISHOP_REPRESENTATION = 'B';
-    public static final char WHITE_KNIGHT_REPRESENTATION = 'n';
-    public static final char BLACK_KNIGHT_REPRESENTATION = 'N';
+    public enum Color {
+        WHITE("white"), BLACK("black"), NOCOLOR("null");
+
+        private final String color;
+
+        Color(String color) {
+            this.color = color;
+        }
+
+        public String getColor() {
+            return color;
+        }
+    }
+
+    public enum Type {
+        PAWN('p'),
+        ROOK('r'),
+        KNIGHT('n'),
+        BISHOP('b'),
+        QUEEN('q'),
+        KING('k'),
+        NO_PIECE('.');
+
+        private final char representation;
+
+        Type(char representation) {
+            this.representation = representation;
+        }
+
+        public char getType() {
+            return representation;
+        }
+
+        public char getBlackType() {
+            return Character.toUpperCase(representation);
+        }
+
+        public char getWhiteType() {
+            return Character.toLowerCase(representation);
+        }
+    }
 
     private final String name;
-    private final String color;
-    private final char representation;
+    private final Color color;
+    private final Type representation;
 
-    private Piece(String name, String color, char representation) {
+    private Piece(String name, Color color, Type representation) {
         this.name = name;
         this.color = color;
         this.representation = representation;
     }
 
     public static Piece createWhitePawn() {
-        return new Piece(PAWN_NAME, WHITE_COLOR, WHITE_PAWN_REPRESENTATION);
+        return new Piece(PAWN_NAME, Color.WHITE, Type.PAWN);
     }
 
     public static Piece createBlackPawn() {
-        return new Piece(PAWN_NAME, BLACK_COLOR, BLACK_PAWN_REPRESENTATION);
+        return new Piece(PAWN_NAME, Color.BLACK, Type.PAWN);
     }
 
     public static Piece createWhiteQueen() {
-        return new Piece(QUEEN_NAME, WHITE_COLOR, WHITE_QUEEN_REPRESENTATION);
+        return new Piece(QUEEN_NAME, Color.WHITE, Type.QUEEN);
     }
 
     public static Piece createBlackQueen() {
-        return new Piece(QUEEN_NAME, BLACK_COLOR, BLACK_QUEEN_REPRESENTATION);
+        return new Piece(QUEEN_NAME, Color.BLACK, Type.QUEEN);
     }
 
     public static Piece createWhiteKing() {
-        return new Piece(KING_NAME, WHITE_COLOR, WHITE_KING_REPRESENTATION);
+        return new Piece(KING_NAME, Color.WHITE, Type.KING);
     }
 
     public static Piece createBlackKing() {
-        return new Piece(KING_NAME, BLACK_COLOR, BLACK_KING_REPRESENTATION);
+        return new Piece(KING_NAME, Color.BLACK, Type.KING);
     }
 
     public static Piece createWhiteRook() {
-        return new Piece(ROOK_NAME, WHITE_COLOR, WHITE_ROOK_REPRESENTATION);
+        return new Piece(ROOK_NAME, Color.WHITE, Type.ROOK);
     }
 
     public static Piece createBlackRook() {
-        return new Piece(ROOK_NAME, BLACK_COLOR, BLACK_ROOK_REPRESENTATION);
+        return new Piece(ROOK_NAME, Color.BLACK, Type.ROOK);
     }
 
     public static Piece createWhiteBishop() {
-        return new Piece(BISHOP_NAME, WHITE_COLOR, WHITE_BISHOP_REPRESENTATION);
+        return new Piece(BISHOP_NAME, Color.WHITE, Type.BISHOP);
     }
 
     public static Piece createBlackBishop() {
-        return new Piece(BISHOP_NAME, BLACK_COLOR, BLACK_BISHOP_REPRESENTATION);
+        return new Piece(BISHOP_NAME, Color.BLACK, Type.BISHOP);
     }
 
     public static Piece createWhiteKnight() {
-        return new Piece(KNIGHT_NAME, WHITE_COLOR, WHITE_KNIGHT_REPRESENTATION);
+        return new Piece(KNIGHT_NAME, Color.WHITE, Type.KNIGHT);
     }
 
     public static Piece createBlackKnight() {
-        return new Piece(KNIGHT_NAME, BLACK_COLOR, BLACK_KNIGHT_REPRESENTATION);
+        return new Piece(KNIGHT_NAME, Color.BLACK, Type.KNIGHT);
     }
 
     public boolean isWhite() {
-        return color.equals(WHITE_COLOR);
+        return color.equals(Color.WHITE);
     }
 
     public boolean isBlack() {
-        return color.equals(BLACK_COLOR);
+        return color.equals(Color.BLACK);
     }
 
     public String getName() {
         return name;
     }
 
-    public String getColor() {
+    public Color getColor() {
         return color;
     }
 
-    public char getRepresentation() {
+    public Type getType() {
         return representation;
     }
 

--- a/app/src/main/java/org/chess/domain/pieces/Piece.java
+++ b/app/src/main/java/org/chess/domain/pieces/Piece.java
@@ -6,7 +6,7 @@ public class Piece {
     public static final String BLACK_COLOR = "black";
 
     public static final String PAWN_NAME = "pawn";
-    public static final String QUENN_NAME = "queen";
+    public static final String QUEEN_NAME = "queen";
     public static final String KING_NAME = "king";
     public static final String ROOK_NAME = "rook";
     public static final String BISHOP_NAME = "bishop";
@@ -43,12 +43,12 @@ public class Piece {
         return new Piece(PAWN_NAME, BLACK_COLOR, BLACK_PAWN_REPRESENTATION);
     }
 
-    public static Piece createWhiteQuenn() {
-        return new Piece(QUENN_NAME, WHITE_COLOR, WHITE_QUEEN_REPRESENTATION);
+    public static Piece createWhiteQueen() {
+        return new Piece(QUEEN_NAME, WHITE_COLOR, WHITE_QUEEN_REPRESENTATION);
     }
 
-    public static Piece createBlackQuenn() {
-        return new Piece(QUENN_NAME, BLACK_COLOR, BLACK_QUEEN_REPRESENTATION);
+    public static Piece createBlackQueen() {
+        return new Piece(QUEEN_NAME, BLACK_COLOR, BLACK_QUEEN_REPRESENTATION);
     }
 
     public static Piece createWhiteKing() {

--- a/app/src/test/java/org/chess/domain/board/BoardTest.java
+++ b/app/src/test/java/org/chess/domain/board/BoardTest.java
@@ -3,6 +3,8 @@ package org.chess.domain.board;
 import org.chess.domain.pieces.Piece;
 import org.junit.jupiter.api.*;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.*;
 import static org.chess.utils.StringUtils.appendNewLine;
 
@@ -148,8 +150,73 @@ class BoardTest {
         System.out.println(board.showBoard());
     }
 
+    @Test
+    @DisplayName("검은색과 흰색 기물을 구분해서 점수가 높은 순으로 정렬할 수 있어야 한다")
+    void 기물_정렬_테스트() {
+        // given
+        Board board = new Board();
+        board.initializeEmptyBoard();
+
+        // when
+        addPiece(board, "b6", Piece.createBlack(Piece.Type.PAWN));
+        addPiece(board, "e6", Piece.createBlack(Piece.Type.QUEEN));
+        addPiece(board, "b8", Piece.createBlack(Piece.Type.KING));
+        addPiece(board, "c8", Piece.createBlack(Piece.Type.ROOK));
+
+        addPiece(board, "f2", Piece.createWhite(Piece.Type.PAWN));
+        addPiece(board, "g2", Piece.createWhite(Piece.Type.PAWN));
+        addPiece(board, "e1", Piece.createWhite(Piece.Type.ROOK));
+        addPiece(board, "f1", Piece.createWhite(Piece.Type.KING));
+
+        // then
+        List<Piece> actualBlackPiecesWithAsc = board.sortPiecesByAscending(Piece.Color.BLACK);
+        List<Piece> actualWhitePiecesWithDesc = board.sortPiecesByDescending(Piece.Color.WHITE);
+        List<Piece> actualBlackPiecesWithDesc = board.sortPiecesByDescending(Piece.Color.BLACK);
+        List<Piece> actualWhitePiecesWithAsc = board.sortPiecesByAscending(Piece.Color.WHITE);
+
+        List<Piece> expectedBlackPiecesWithAsc = List.of(
+                Piece.createBlack(Piece.Type.KING),   // 0.0
+                Piece.createBlack(Piece.Type.PAWN),   // 1.0
+                Piece.createBlack(Piece.Type.ROOK),   // 5.0
+                Piece.createBlack(Piece.Type.QUEEN)   // 9.0
+        );
+
+        List<Piece> expectedBlackPiecesWithDesc = List.of(
+                Piece.createBlack(Piece.Type.QUEEN),  // 9.0
+                Piece.createBlack(Piece.Type.ROOK),   // 5.0
+                Piece.createBlack(Piece.Type.PAWN),   // 1.0
+                Piece.createBlack(Piece.Type.KING)    // 0.0
+        );
+
+        List<Piece> expectedWhitePiecesWithAsc = List.of(
+                Piece.createWhite(Piece.Type.KING),   // 0.0
+                Piece.createWhite(Piece.Type.PAWN),   // 1.0
+                Piece.createWhite(Piece.Type.PAWN),   // 1.0
+                Piece.createWhite(Piece.Type.ROOK)    // 5.0
+        );
+
+        List<Piece> expectedWhitePiecesWithDesc = List.of(
+                Piece.createWhite(Piece.Type.ROOK),   // 5.0
+                Piece.createWhite(Piece.Type.PAWN),   // 1.0
+                Piece.createWhite(Piece.Type.PAWN),   // 1.0
+                Piece.createWhite(Piece.Type.KING)    // 0.0
+        );
+
+        compare(actualBlackPiecesWithAsc, expectedBlackPiecesWithAsc);
+        compare(actualWhitePiecesWithDesc, expectedWhitePiecesWithDesc);
+        compare(actualBlackPiecesWithDesc, expectedBlackPiecesWithDesc);
+        compare(actualWhitePiecesWithAsc, expectedWhitePiecesWithAsc);
+    }
+
     private void addPiece(Board board, String Position, Piece piece) {
         board.move(Position, piece);
+    }
+
+    private void compare(List<Piece> actual, List<Piece> expected) {
+        assertThat(actual.size()).isEqualTo(expected.size());
+        for (int i = 0; i < actual.size(); i++) {
+            assertThat(actual.get(i)).isEqualTo(expected.get(i));
+        }
     }
 
 }

--- a/app/src/test/java/org/chess/domain/board/BoardTest.java
+++ b/app/src/test/java/org/chess/domain/board/BoardTest.java
@@ -77,9 +77,13 @@ class BoardTest {
     @Test
     @DisplayName("Piece 의 색과 종류를 반환할 수 있어야 한다")
     void 기물의_개수_반환_테스트() {
+        // given
         Board board = new Board();
+
+        // when
         board.initialize();
 
+        // then
         assertThat(8).isEqualTo(board.countPieces(Piece.Color.WHITE, Piece.Type.PAWN));
         assertThat(2).isEqualTo(board.countPieces(Piece.Color.WHITE, Piece.Type.ROOK));
         assertThat(2).isEqualTo(board.countPieces(Piece.Color.WHITE, Piece.Type.KNIGHT));

--- a/app/src/test/java/org/chess/domain/board/BoardTest.java
+++ b/app/src/test/java/org/chess/domain/board/BoardTest.java
@@ -116,4 +116,18 @@ class BoardTest {
                 .containsExactly(Piece.Color.WHITE, Piece.Type.ROOK);
     }
 
+    @Test
+    @DisplayName("임의의 기물을 체스판위에 추가할 수 있어야 한다")
+    void 기물_추가_테스트() {
+        // given
+        Board board = new Board();
+        board.initializeEmptyBoard();
+
+        String position = "b5";
+        Piece piece = Piece.createWhite(Piece.Type.ROOK);
+        board.move(position, piece);
+
+        assertThat(piece).isEqualTo(board.findPiece(position));
+    }
+
 }

--- a/app/src/test/java/org/chess/domain/board/BoardTest.java
+++ b/app/src/test/java/org/chess/domain/board/BoardTest.java
@@ -74,4 +74,15 @@ class BoardTest {
                 .isEqualTo(board.showBoard());
     }
 
+    @Test
+    @DisplayName("Piece 의 색과 종류를 반환할 수 있어야 한다")
+    void 기물의_개수_반환_테스트() {
+        Board board = new Board();
+        board.initialize();
+
+        assertThat(8).isEqualTo(board.countPieces(Piece.Color.WHITE, Piece.Type.PAWN));
+        assertThat(2).isEqualTo(board.countPieces(Piece.Color.WHITE, Piece.Type.ROOK));
+        assertThat(2).isEqualTo(board.countPieces(Piece.Color.WHITE, Piece.Type.KNIGHT));
+    }
+
 }

--- a/app/src/test/java/org/chess/domain/board/BoardTest.java
+++ b/app/src/test/java/org/chess/domain/board/BoardTest.java
@@ -89,4 +89,31 @@ class BoardTest {
         assertThat(2).isEqualTo(board.countPieces(Piece.Color.WHITE, Piece.Type.KNIGHT));
     }
 
+    @Test
+    @DisplayName("임의의 주어진 위치의 기물을 조회할 수 있어야 한다")
+    void 기물_조회_테스트() {
+        // given
+        Board board = new Board();
+
+        // when
+        board.initialize();
+
+        // then
+        // Black Rook at a8 and h8
+        assertThat(board.findPiece("a8"))
+                .extracting("color", "type")
+                .containsExactly(Piece.Color.BLACK, Piece.Type.ROOK);
+        assertThat(board.findPiece("h8"))
+                .extracting("color", "type")
+                .containsExactly(Piece.Color.BLACK, Piece.Type.ROOK);
+
+        // White Rook at a1 and h1
+        assertThat(board.findPiece("a1"))
+                .extracting("color", "type")
+                .containsExactly(Piece.Color.WHITE, Piece.Type.ROOK);
+        assertThat(board.findPiece("h1"))
+                .extracting("color", "type")
+                .containsExactly(Piece.Color.WHITE, Piece.Type.ROOK);
+    }
+
 }

--- a/app/src/test/java/org/chess/domain/board/BoardTest.java
+++ b/app/src/test/java/org/chess/domain/board/BoardTest.java
@@ -13,8 +13,8 @@ class BoardTest {
 
     @BeforeEach
     void setUp() {
-        this.whitePawn = Piece.createWhitePawn();
-        this.blackPawn = Piece.createBlackPawn();
+        this.whitePawn = Piece.createWhite(Piece.Type.PAWN);
+        this.blackPawn = Piece.createBlack(Piece.Type.PAWN);
     }
 
     @Test

--- a/app/src/test/java/org/chess/domain/board/BoardTest.java
+++ b/app/src/test/java/org/chess/domain/board/BoardTest.java
@@ -99,21 +99,14 @@ class BoardTest {
         board.initialize();
 
         // then
-        // Black Rook at a8 and h8
-        assertThat(board.findPiece("a8"))
-                .extracting("color", "type")
-                .containsExactly(Piece.Color.BLACK, Piece.Type.ROOK);
-        assertThat(board.findPiece("h8"))
-                .extracting("color", "type")
-                .containsExactly(Piece.Color.BLACK, Piece.Type.ROOK);
-
-        // White Rook at a1 and h1
-        assertThat(board.findPiece("a1"))
-                .extracting("color", "type")
-                .containsExactly(Piece.Color.WHITE, Piece.Type.ROOK);
-        assertThat(board.findPiece("h1"))
-                .extracting("color", "type")
-                .containsExactly(Piece.Color.WHITE, Piece.Type.ROOK);
+        assertThat(Piece.createBlack(Piece.Type.ROOK))
+                .isEqualTo(board.findPiece("h8"));
+        assertThat(Piece.createWhite(Piece.Type.ROOK))
+                .isEqualTo(board.findPiece("h1"));
+        assertThat(Piece.createBlack(Piece.Type.ROOK))
+                .isEqualTo(board.findPiece("a8"));
+        assertThat(Piece.createWhite(Piece.Type.ROOK))
+                .isEqualTo(board.findPiece("a1"));
     }
 
     @Test

--- a/app/src/test/java/org/chess/domain/board/BoardTest.java
+++ b/app/src/test/java/org/chess/domain/board/BoardTest.java
@@ -142,8 +142,8 @@ class BoardTest {
         addPiece(board, "f1", Piece.createWhite(Piece.Type.KING));
 
         // then
-        assertThat(board.caculatePoint(Piece.Color.BLACK), 0.01).isEqualTo(15.0);
-        assertThat(board.caculatePoint(Piece.Color.WHITE), 0.01).isEqualTo(7.0);
+        assertThat(board.calculatePoint(Piece.Color.BLACK)).isCloseTo(15.0, within(0.01));
+        assertThat(board.calculatePoint(Piece.Color.WHITE)).isCloseTo(7.0, within(0.01));
 
         System.out.println(board.showBoard());
     }

--- a/app/src/test/java/org/chess/domain/board/BoardTest.java
+++ b/app/src/test/java/org/chess/domain/board/BoardTest.java
@@ -123,4 +123,33 @@ class BoardTest {
         assertThat(piece).isEqualTo(board.findPiece(position));
     }
 
+    @Test
+    @DisplayName("현재까지 남아있는 기물에 따라 점수를 계산할 수 있어야 한다")
+    void 점수_계산_테스트() {
+        // given
+        Board board = new Board();
+        board.initializeEmptyBoard();
+
+        // when
+        addPiece(board, "b6", Piece.createBlack(Piece.Type.PAWN));
+        addPiece(board, "e6", Piece.createBlack(Piece.Type.QUEEN));
+        addPiece(board, "b8", Piece.createBlack(Piece.Type.KING));
+        addPiece(board, "c8", Piece.createBlack(Piece.Type.ROOK));
+
+        addPiece(board, "f2", Piece.createWhite(Piece.Type.PAWN));
+        addPiece(board, "g2", Piece.createWhite(Piece.Type.PAWN));
+        addPiece(board, "e1", Piece.createWhite(Piece.Type.ROOK));
+        addPiece(board, "f1", Piece.createWhite(Piece.Type.KING));
+
+        // then
+        assertThat(board.caculatePoint(Piece.Color.BLACK), 0.01).isEqualTo(15.0);
+        assertThat(board.caculatePoint(Piece.Color.WHITE), 0.01).isEqualTo(7.0);
+
+        System.out.println(board.showBoard());
+    }
+
+    private void addPiece(Board board, String Position, Piece piece) {
+        board.move(Position, piece);
+    }
+
 }

--- a/app/src/test/java/org/chess/domain/board/PositionTest.java
+++ b/app/src/test/java/org/chess/domain/board/PositionTest.java
@@ -1,0 +1,31 @@
+package org.chess.domain.board;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PositionTest {
+
+    private Board board;
+
+    @BeforeEach
+    void setUp() {
+        this.board = new Board();
+    }
+
+    @Test
+    @DisplayName("'a8'같은 문자열 좌표를 분리할 수 있어야 한다")
+    void Postion_좌표_분리_테스트() {
+        // given
+        String pos = "a8";
+
+        // when
+        Position position = Position.of(pos);
+
+        // then
+        Assertions.assertThat(position.y()).isEqualTo(0);
+        Assertions.assertThat(position.x()).isEqualTo(0);
+    }
+
+}

--- a/app/src/test/java/org/chess/domain/board/RankTest.java
+++ b/app/src/test/java/org/chess/domain/board/RankTest.java
@@ -1,0 +1,30 @@
+package org.chess.domain.board;
+
+import org.chess.domain.pieces.Piece;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RankTest {
+
+    @Test
+    @DisplayName("Rank 내에 Pieces를 반환할 수 있어야 한다")
+    void Rank_내에_Pieces_반환_테스트() {
+        // given
+        List<Piece> pieces = List.of(
+                Piece.createWhite(Piece.Type.ROOK), Piece.createWhite(Piece.Type.KNIGHT), Piece.createWhite(Piece.Type.BISHOP),
+                Piece.createWhite(Piece.Type.QUEEN), Piece.createWhite(Piece.Type.KING), Piece.createWhite(Piece.Type.BISHOP),
+                Piece.createWhite(Piece.Type.KNIGHT), Piece.createWhite(Piece.Type.ROOK)
+        );
+
+        // when
+        Rank rank = Rank.of(pieces);
+
+        // then
+        assertThat(pieces).isEqualTo(rank.getPieces());
+    }
+
+}

--- a/app/src/test/java/org/chess/domain/board/RankTest.java
+++ b/app/src/test/java/org/chess/domain/board/RankTest.java
@@ -27,4 +27,22 @@ class RankTest {
         assertThat(pieces).isEqualTo(rank.getPieces());
     }
 
+    @Test
+    @DisplayName("현재 Rank 에 Pieces 가 색상에 따라 출력되어야 한다")
+    void 색상에_따른_반환_테스트() {
+        // given
+        List<Piece> pieces = List.of(
+                Piece.createWhite(Piece.Type.ROOK), Piece.createBlack(Piece.Type.KNIGHT), Piece.createWhite(Piece.Type.BISHOP),
+                Piece.createWhite(Piece.Type.QUEEN), Piece.createBlack(Piece.Type.KING), Piece.createWhite(Piece.Type.BISHOP),
+                Piece.createWhite(Piece.Type.KNIGHT), Piece.createBlack(Piece.Type.ROOK)
+        );
+        Rank rank = Rank.of(pieces);
+
+        // when
+        String rankString = rank.toString();
+
+        // then
+        assertThat(rankString).isEqualTo("rNbqKbnR");
+    }
+
 }

--- a/app/src/test/java/org/chess/domain/pieces/PieceTest.java
+++ b/app/src/test/java/org/chess/domain/pieces/PieceTest.java
@@ -15,8 +15,8 @@ class PieceTest {
     void Piece_생성_테스트() {
         verifyPiece(Piece.createWhitePawn(), Piece.WHITE_COLOR, Piece.WHITE_PAWN_REPRESENTATION);
         verifyPiece(Piece.createBlackPawn(), Piece.BLACK_COLOR, Piece.BLACK_PAWN_REPRESENTATION);
-        verifyPiece(Piece.createWhiteQuenn(), Piece.WHITE_COLOR, Piece.WHITE_QUEEN_REPRESENTATION);
-        verifyPiece(Piece.createBlackQuenn(), Piece.BLACK_COLOR, Piece.BLACK_QUEEN_REPRESENTATION);
+        verifyPiece(Piece.createWhiteQueen(), Piece.WHITE_COLOR, Piece.WHITE_QUEEN_REPRESENTATION);
+        verifyPiece(Piece.createBlackQueen(), Piece.BLACK_COLOR, Piece.BLACK_QUEEN_REPRESENTATION);
         verifyPiece(Piece.createWhiteKing(), Piece.WHITE_COLOR, Piece.WHITE_KING_REPRESENTATION);
         verifyPiece(Piece.createBlackKing(), Piece.BLACK_COLOR, Piece.BLACK_KING_REPRESENTATION);
         verifyPiece(Piece.createWhiteRook(), Piece.WHITE_COLOR, Piece.WHITE_ROOK_REPRESENTATION);
@@ -49,7 +49,7 @@ class PieceTest {
     static Stream<Piece> whitePiecesProvider() {
         return Stream.of(
                 Piece.createWhitePawn(),
-                Piece.createWhiteQuenn(),
+                Piece.createWhiteQueen(),
                 Piece.createWhiteKing(),
                 Piece.createWhiteRook(),
                 Piece.createWhiteBishop(),
@@ -60,7 +60,7 @@ class PieceTest {
     static Stream<Piece> blackPiecesProvider() {
         return Stream.of(
                 Piece.createBlackPawn(),
-                Piece.createBlackQuenn(),
+                Piece.createBlackQueen(),
                 Piece.createBlackKing(),
                 Piece.createBlackRook(),
                 Piece.createBlackBishop(),

--- a/app/src/test/java/org/chess/domain/pieces/PieceTest.java
+++ b/app/src/test/java/org/chess/domain/pieces/PieceTest.java
@@ -13,12 +13,12 @@ class PieceTest {
     @Test
     @DisplayName("팩토리 메소드에 의해 맞는 색상과 표현을 가진 Piece를 생성할 수 있어야 한다")
     void Piece_생성_테스트() {
-        verifyPiece(Piece.createWhitePawn(), Piece.createBlackPawn(), Piece.Type.PAWN);
-        verifyPiece(Piece.createWhiteKnight(), Piece.createBlackKnight(), Piece.Type.KNIGHT);
-        verifyPiece(Piece.createWhiteRook(), Piece.createBlackRook(), Piece.Type.ROOK);
-        verifyPiece(Piece.createWhiteBishop(), Piece.createBlackBishop(), Piece.Type.BISHOP);
-        verifyPiece(Piece.createWhiteQueen(), Piece.createBlackQueen(), Piece.Type.QUEEN);
-        verifyPiece(Piece.createWhiteKing(), Piece.createBlackKing(), Piece.Type.KING);
+        verifyPiece(Piece.createWhite(Piece.Type.PAWN), Piece.createBlack(Piece.Type.PAWN), Piece.Type.PAWN);
+        verifyPiece(Piece.createWhite(Piece.Type.KNIGHT), Piece.createBlack(Piece.Type.KNIGHT), Piece.Type.KNIGHT);
+        verifyPiece(Piece.createWhite(Piece.Type.ROOK), Piece.createBlack(Piece.Type.ROOK), Piece.Type.ROOK);
+        verifyPiece(Piece.createWhite(Piece.Type.BISHOP), Piece.createBlack(Piece.Type.BISHOP), Piece.Type.BISHOP);
+        verifyPiece(Piece.createWhite(Piece.Type.QUEEN), Piece.createBlack(Piece.Type.QUEEN), Piece.Type.QUEEN);
+        verifyPiece(Piece.createWhite(Piece.Type.KING), Piece.createBlack(Piece.Type.KING), Piece.Type.KING);
 
         Piece blank = Piece.createBlankPiece();
         assertThat(blank.isWhite()).isFalse();

--- a/app/src/test/java/org/chess/domain/pieces/PieceTest.java
+++ b/app/src/test/java/org/chess/domain/pieces/PieceTest.java
@@ -58,23 +58,23 @@ class PieceTest {
 
     static Stream<Piece> whitePiecesProvider() {
         return Stream.of(
-                Piece.createWhitePawn(),
-                Piece.createWhiteQueen(),
-                Piece.createWhiteKing(),
-                Piece.createWhiteRook(),
-                Piece.createWhiteBishop(),
-                Piece.createWhiteKnight()
+                Piece.createWhite(Piece.Type.PAWN),
+                Piece.createWhite(Piece.Type.QUEEN),
+                Piece.createWhite(Piece.Type.KING),
+                Piece.createWhite(Piece.Type.ROOK),
+                Piece.createWhite(Piece.Type.BISHOP),
+                Piece.createWhite(Piece.Type.KNIGHT)
         );
     }
 
     static Stream<Piece> blackPiecesProvider() {
         return Stream.of(
-                Piece.createBlackPawn(),
-                Piece.createBlackQueen(),
-                Piece.createBlackKing(),
-                Piece.createBlackRook(),
-                Piece.createBlackBishop(),
-                Piece.createBlackKnight()
+                Piece.createBlack(Piece.Type.PAWN),
+                Piece.createBlack(Piece.Type.QUEEN),
+                Piece.createBlack(Piece.Type.KING),
+                Piece.createBlack(Piece.Type.ROOK),
+                Piece.createBlack(Piece.Type.BISHOP),
+                Piece.createBlack(Piece.Type.KNIGHT)
         );
     }
 

--- a/app/src/test/java/org/chess/domain/pieces/PieceTest.java
+++ b/app/src/test/java/org/chess/domain/pieces/PieceTest.java
@@ -13,23 +13,30 @@ class PieceTest {
     @Test
     @DisplayName("팩토리 메소드에 의해 맞는 색상과 표현을 가진 Piece를 생성할 수 있어야 한다")
     void Piece_생성_테스트() {
-        verifyPiece(Piece.createWhitePawn(), Piece.WHITE_COLOR, Piece.WHITE_PAWN_REPRESENTATION);
-        verifyPiece(Piece.createBlackPawn(), Piece.BLACK_COLOR, Piece.BLACK_PAWN_REPRESENTATION);
-        verifyPiece(Piece.createWhiteQueen(), Piece.WHITE_COLOR, Piece.WHITE_QUEEN_REPRESENTATION);
-        verifyPiece(Piece.createBlackQueen(), Piece.BLACK_COLOR, Piece.BLACK_QUEEN_REPRESENTATION);
-        verifyPiece(Piece.createWhiteKing(), Piece.WHITE_COLOR, Piece.WHITE_KING_REPRESENTATION);
-        verifyPiece(Piece.createBlackKing(), Piece.BLACK_COLOR, Piece.BLACK_KING_REPRESENTATION);
-        verifyPiece(Piece.createWhiteRook(), Piece.WHITE_COLOR, Piece.WHITE_ROOK_REPRESENTATION);
-        verifyPiece(Piece.createBlackRook(), Piece.BLACK_COLOR, Piece.BLACK_ROOK_REPRESENTATION);
-        verifyPiece(Piece.createWhiteBishop(), Piece.WHITE_COLOR, Piece.WHITE_BISHOP_REPRESENTATION);
-        verifyPiece(Piece.createBlackBishop(), Piece.BLACK_COLOR, Piece.BLACK_BISHOP_REPRESENTATION);
-        verifyPiece(Piece.createWhiteKnight(), Piece.WHITE_COLOR, Piece.WHITE_KNIGHT_REPRESENTATION);
-        verifyPiece(Piece.createBlackKnight(), Piece.BLACK_COLOR, Piece.BLACK_KNIGHT_REPRESENTATION);
+        verifyPiece(Piece.createWhitePawn(), Piece.Color.WHITE, Piece.Type.PAWN);
+        verifyPiece(Piece.createBlackPawn(), Piece.Color.BLACK, Piece.Type.PAWN);
+        verifyPiece(Piece.createWhiteQueen(), Piece.Color.WHITE, Piece.Type.QUEEN);
+        verifyPiece(Piece.createBlackQueen(), Piece.Color.BLACK, Piece.Type.QUEEN);
+        verifyPiece(Piece.createWhiteKing(), Piece.Color.WHITE, Piece.Type.KING);
+        verifyPiece(Piece.createBlackKing(), Piece.Color.BLACK, Piece.Type.KING);
+        verifyPiece(Piece.createWhiteRook(), Piece.Color.WHITE, Piece.Type.ROOK);
+        verifyPiece(Piece.createBlackRook(), Piece.Color.BLACK, Piece.Type.ROOK);
+        verifyPiece(Piece.createWhiteBishop(), Piece.Color.WHITE, Piece.Type.BISHOP);
+        verifyPiece(Piece.createBlackBishop(), Piece.Color.BLACK, Piece.Type.BISHOP);
+        verifyPiece(Piece.createWhiteKnight(), Piece.Color.WHITE, Piece.Type.KNIGHT);
+        verifyPiece(Piece.createBlackKnight(), Piece.Color.BLACK, Piece.Type.KNIGHT);
     }
 
-    private void verifyPiece(final Piece piece, final String color, final char representation) {
+    private void verifyPiece(final Piece piece, final Piece.Color color, final Piece.Type type) {
         assertThat(piece.getColor()).isEqualTo(color);
-        assertThat(piece.getRepresentation()).isEqualTo(representation);
+        assertThat(piece.getType()).isEqualTo(type);
+    }
+
+    @Test
+    @DisplayName("Piece의 표현을 검은 색과 흰 색에 따라 반환해야 한다")
+    void enum_Type_표현_반환_테스트() {
+        assertThat('p').isEqualTo(Piece.Type.PAWN.getWhiteType());
+        assertThat('P').isEqualTo(Piece.Type.PAWN.getBlackType());
     }
 
     @ParameterizedTest

--- a/app/src/test/java/org/chess/domain/pieces/PieceTest.java
+++ b/app/src/test/java/org/chess/domain/pieces/PieceTest.java
@@ -13,23 +13,26 @@ class PieceTest {
     @Test
     @DisplayName("팩토리 메소드에 의해 맞는 색상과 표현을 가진 Piece를 생성할 수 있어야 한다")
     void Piece_생성_테스트() {
-        verifyPiece(Piece.createWhitePawn(), Piece.Color.WHITE, Piece.Type.PAWN);
-        verifyPiece(Piece.createBlackPawn(), Piece.Color.BLACK, Piece.Type.PAWN);
-        verifyPiece(Piece.createWhiteQueen(), Piece.Color.WHITE, Piece.Type.QUEEN);
-        verifyPiece(Piece.createBlackQueen(), Piece.Color.BLACK, Piece.Type.QUEEN);
-        verifyPiece(Piece.createWhiteKing(), Piece.Color.WHITE, Piece.Type.KING);
-        verifyPiece(Piece.createBlackKing(), Piece.Color.BLACK, Piece.Type.KING);
-        verifyPiece(Piece.createWhiteRook(), Piece.Color.WHITE, Piece.Type.ROOK);
-        verifyPiece(Piece.createBlackRook(), Piece.Color.BLACK, Piece.Type.ROOK);
-        verifyPiece(Piece.createWhiteBishop(), Piece.Color.WHITE, Piece.Type.BISHOP);
-        verifyPiece(Piece.createBlackBishop(), Piece.Color.BLACK, Piece.Type.BISHOP);
-        verifyPiece(Piece.createWhiteKnight(), Piece.Color.WHITE, Piece.Type.KNIGHT);
-        verifyPiece(Piece.createBlackKnight(), Piece.Color.BLACK, Piece.Type.KNIGHT);
+        verifyPiece(Piece.createWhitePawn(), Piece.createBlackPawn(), Piece.Type.PAWN);
+        verifyPiece(Piece.createWhiteKnight(), Piece.createBlackKnight(), Piece.Type.KNIGHT);
+        verifyPiece(Piece.createWhiteRook(), Piece.createBlackRook(), Piece.Type.ROOK);
+        verifyPiece(Piece.createWhiteBishop(), Piece.createBlackBishop(), Piece.Type.BISHOP);
+        verifyPiece(Piece.createWhiteQueen(), Piece.createBlackQueen(), Piece.Type.QUEEN);
+        verifyPiece(Piece.createWhiteKing(), Piece.createBlackKing(), Piece.Type.KING);
+
+        Piece blank = Piece.createBlankPiece();
+        assertThat(blank.isWhite()).isFalse();
+        assertThat(blank.isBlack()).isFalse();
+        assertThat(blank.getType()).isEqualTo(Piece.Type.NO_PIECE);
     }
 
-    private void verifyPiece(final Piece piece, final Piece.Color color, final Piece.Type type) {
-        assertThat(piece.getColor()).isEqualTo(color);
-        assertThat(piece.getType()).isEqualTo(type);
+    private void verifyPiece(final Piece whitePiece, final Piece blackPiece, final Piece.Type type) {
+        assertThat(whitePiece.isWhite()).isTrue();
+        assertThat(whitePiece.getType()).isEqualTo(type);
+
+
+        assertThat(blackPiece.isBlack()).isTrue();
+        assertThat(blackPiece.getType()).isEqualTo(type);
     }
 
     @Test


### PR DESCRIPTION
## 구현 내용
- **`Piece` 클래스 개선**
  - `Color` enum 추가 (`WHITE`, `BLACK`, `NOCOLOR`)
  - `Type` enum 추가 (`PAWN`, `ROOK`, `KNIGHT`, `BISHOP`, `QUEEN`, `KING`, `NO_PIECE`)
    - 각 기물에 대한 **식별 문자**를 함께 관리 (소문자로 통일)
  - 기존 상수 값 제거 후, `enum`을 이용한 방식으로 변경.

- **`Piece` 클래스 리팩토링**
  - `createWhite(type: Type): Piece`, `createBlack(type: Type): Piece` 팩토리 메소드 추가.

- **`Board` 클래스 변경**
  - `initialize()` 메소드에서 빈 공간도 `Piece.createBlank()`로 초기화.
  - 기존 `List<Piece>` 관리 방식에서 `Rank(row)` 기반으로 `List<Piece>`를 관리하도록 수정.

- **기물 개수 조회 기능 추가**
  - `Board` 클래스에 `countPieces: Color, type: Type): int` 메소드 추가.
    - 특정 색상(`Color`)과 특정 기물(`Type`)의 개수를 반환.
    - _예시:_ `countPieceByColorAndType(Color.BLACK, Type.PAWN)`

- **기물 위치 조회 기능 추가**
  - `Board` 클래스에 `findPiece(position: String): Piece` 메소드 추가.
  - 위치(`row`: 1~8, `column`: a~h)를 사용하여 기물을 조회.
  - 좌측 상단이 `(8, a)`, 우측 하단이 `(1, h)` 위치 기준.
    - _예시:_ `findPiece("a1")`
- **`Position`** 클래수 추가
  - String 으로 들어오는 좌표값 (ex, "a8") 을 효율적으로 관리

- **임의의 기물 추가 기능**
  - `Board` 클래스에 `move(to: String, piece: Piece): void` 메소드 추가.
  - 기존 체스판에 임의의 기물을 배치하기 위해 **빈 체스판**을 생성 후 `move()` 메소드로 이동 가능.
  - 기존 `List<Piece>`에서 제거 후 새로운 `Piece`로 변경할 때 `set()` 메소드 사용.

- **점수 계산 기능 추가**
  - `Board` 클래스에 `calculatePoint(color: Color): double` 메소드 추가.
  - 각 기물의 점수 부여:
    - 폰: **1.0**
    - 룩: **5.0**
    - 나이트: **2.5**
    - 비숍: **3.0**
    - 퀸: **9.0**
    - 킹: **0.0**
  - 특정 색상의 기물 점수 합산 기능 제공.
    - _예시:_ `calculatePoint(Color.WHITE)`
  - **점수가 높은 순서대로 정렬**하는 기능 추가.
  - 특정 색상의 모든 기물을 `Collection`에 담아 정렬.


## 고민 사항

- 인터페이스를 어디에 어떻게 적용할지 고민이 많았음.
  - `Piece`클래스 자체를 인터페이스로 두고 여러 기물 클래스를 구현하는 방법을 고민 했지만 오히려 클래스가 많아져서 관리가 힘들어지지 않을까에 대한 고민

## 기타
