### PR TITLE
[BRIE] Step2-6,7 기물 이동 구현 및 예외 처리

### DIFF
--- a/app/src/main/java/chess/Board.java
+++ b/app/src/main/java/chess/Board.java
@@ -8,47 +8,45 @@ import java.util.ArrayList;
 public class Board {
     private final ArrayList<Rank> board = new ArrayList<>();
 
+    private static final int BOARD_SIZE = 8;
+    private static final int BLACK_PAWN_ROW = 6;
+    private static final int WHITE_PAWN_ROW = 1;
+    private static final int WHITE_ROW = 0;
+    private static final int BLACK_ROW = 7;
+
+
     public Board() {
-        for (int i = 0; i < 8; i++) {
+        for (int i = 0; i < BOARD_SIZE; i++) {
             board.add(new Rank());
         }
     }
 
     public void initializeEmpty() {
         board.clear();
-        for (int i = 0; i < 8; i++) {
+        for (int i = 0; i < BOARD_SIZE; i++) {
             board.add(new Rank());
         }
     }
 
     public void initialize() {
+        Piece.Type[] pieceOrder = {Type.ROOK, Type.KNIGHT, Type.BISHOP, Type.QUEEN, Type.KING, Type.BISHOP, Type.KNIGHT, Type.ROOK};
         board.clear();
 
-        for (int i = 0; i < 8; i++) {
+        for (int i = 0; i < BOARD_SIZE; i++) {
             board.add(new Rank());  // Rank 객체를 다시 추가 -> clear()를 하면 체스판이 비어버림. 다시 Rank를 추가해줘야함.
         }
 
-
-        for (int i = 0; i < 8; i++) {
-            setPiece(6, i, Piece.createBlack(Type.PAWN));
-            setPiece(1, i, Piece.createWhite(Type.PAWN));
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            board.get(BLACK_PAWN_ROW).setPiece(i, Piece.createBlack(Type.PAWN));
+            board.get(WHITE_PAWN_ROW).setPiece(i, Piece.createWhite(Type.PAWN));
         }
-        setPiece(0, 0, Piece.createWhite(Type.ROOK));
-        setPiece(7, 0, Piece.createBlack(Type.ROOK));
-        setPiece(0, 1, Piece.createWhite(Type.KNIGHT));
-        setPiece(7, 1, Piece.createBlack(Type.KNIGHT));
-        setPiece(0, 2, Piece.createWhite(Type.BISHOP));
-        setPiece(7, 2, Piece.createBlack(Type.BISHOP));
-        setPiece(0, 3, Piece.createWhite(Type.QUEEN));
-        setPiece(7, 3, Piece.createBlack(Type.QUEEN));
-        setPiece(0, 4, Piece.createWhite(Type.KING));
-        setPiece(7, 4, Piece.createBlack(Type.KING));
-        setPiece(0, 5, Piece.createWhite(Type.BISHOP));
-        setPiece(7, 5, Piece.createBlack(Type.BISHOP));
-        setPiece(0, 6, Piece.createWhite(Type.KNIGHT));
-        setPiece(7, 6, Piece.createBlack(Type.KNIGHT));
-        setPiece(0, 7, Piece.createWhite(Type.ROOK));
-        setPiece(7, 7, Piece.createBlack(Type.ROOK));
+
+
+        for (int i = 0; i < BOARD_SIZE; i++) {
+            board.get(WHITE_ROW).setPiece(i, Piece.createWhite(pieceOrder[i]));
+            board.get(BLACK_ROW).setPiece(i, Piece.createBlack(pieceOrder[i]));
+        }
+
     }
 
     public void setPiece(int row, int col, Piece piece) {

--- a/app/src/main/java/chess/Board.java
+++ b/app/src/main/java/chess/Board.java
@@ -90,9 +90,21 @@ public class Board {
         return board.get(pos.getRow()).getPiece(pos.getCol());
     }
 
-    public void move(String position, Piece piece) {
+    public void addPiece(String position, Piece piece) {
         Position pos = new Position(position);
         setPiece(pos.getRow(), pos.getCol(), piece);
+    }
+
+    public void removePiece(String position) {
+        Position pos = new Position(position);
+        setPiece(pos.getRow(), pos.getCol(), Piece.createBlank());
+    }
+
+    public void move(String sourcePosition, String targetPosition) {
+        Position targetPos = new Position(targetPosition);
+        Piece piece = findPiece(sourcePosition);
+        removePiece(sourcePosition);
+        setPiece(targetPos.getRow(), targetPos.getCol(), piece);
     }
 
 }

--- a/app/src/main/java/chess/Board.java
+++ b/app/src/main/java/chess/Board.java
@@ -72,10 +72,6 @@ public class Board {
                 .count();
     }
 
-    public Piece findPiece(String position) {
-        Position pos = new Position(position);
-        return board.get(pos.getRow()).getPiece(pos.getCol());
-    }
 
     public void addPiece(String position, Piece piece) {
         Position pos = new Position(position);
@@ -87,12 +83,6 @@ public class Board {
         setPiece(pos.getRow(), pos.getCol(), Piece.createBlank());
     }
 
-    public void move(String sourcePosition, String targetPosition) {
-        Position targetPos = new Position(targetPosition);
-        Piece piece = findPiece(sourcePosition);
-        removePiece(sourcePosition);
-        setPiece(targetPos.getRow(), targetPos.getCol(), piece);
-    }
 
 }
 

--- a/app/src/main/java/chess/Board.java
+++ b/app/src/main/java/chess/Board.java
@@ -63,8 +63,6 @@ public class Board {
     }
 
 
-
-
     public int pieceCount(Piece.Color color, Piece.Type type) {
         return (int) board.stream()
                 .flatMap(rank -> rank.getRow().stream())
@@ -88,6 +86,12 @@ public class Board {
     public void removePiece(String position) {
         Position pos = new Position(position);
         setPiece(pos.getRow(), pos.getCol(), createBlank());
+    }
+
+    public boolean isValidPosition(Position position) {
+        int row = position.getRow();
+        int col = position.getCol();
+        return row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE;
     }
 
 

--- a/app/src/main/java/chess/Board.java
+++ b/app/src/main/java/chess/Board.java
@@ -59,28 +59,17 @@ public class Board {
 
 
     public int pieceCount(Piece.Color color, Piece.Type type) {
-        int cnt = 0;
-        for (Rank row : board) {
-            for (Piece piece : row.getRow()) {
-                if  (piece.getColor() == color&& piece.getType() == type) {
-                    cnt ++;
-                }
-            }
-
-        }
-        return cnt;
+        return (int) board.stream()
+                .flatMap(rank -> rank.getRow().stream())
+                .filter(piece -> piece.getColor() == color && piece.getType() == type)
+                .count();
     }
 
     public int totalPieceCount() {
-        int cnt = 0;
-        for (Rank row : board) {
-            for (Piece piece : row.getRow()) {
-                if (piece.getType() != Piece.Type.NO_PIECE) {
-                    cnt++;
-                }
-            }
-        }
-        return cnt;
+        return (int) board.stream()
+                .flatMap(rank -> rank.getRow().stream())
+                .filter(piece -> piece.getType() != Type.NO_PIECE)
+                .count();
     }
 
     public Piece findPiece(String position) {

--- a/app/src/main/java/chess/Board.java
+++ b/app/src/main/java/chess/Board.java
@@ -1,6 +1,7 @@
 package chess;
 
 import pieces.Piece;
+import static pieces.PieceFactory.*;
 import pieces.Piece.Type;
 import java.util.ArrayList;
 
@@ -37,25 +38,31 @@ public class Board {
         }
 
         for (int i = 0; i < BOARD_SIZE; i++) {
-            board.get(BLACK_PAWN_ROW).setPiece(i, Piece.createBlack(Type.PAWN));
-            board.get(WHITE_PAWN_ROW).setPiece(i, Piece.createWhite(Type.PAWN));
+            board.get(BLACK_PAWN_ROW).setPiece(i, createBlack(Type.PAWN));
+            board.get(WHITE_PAWN_ROW).setPiece(i, createWhite(Type.PAWN));
         }
 
 
         for (int i = 0; i < BOARD_SIZE; i++) {
-            board.get(WHITE_ROW).setPiece(i, Piece.createWhite(pieceOrder[i]));
-            board.get(BLACK_ROW).setPiece(i, Piece.createBlack(pieceOrder[i]));
+            board.get(WHITE_ROW).setPiece(i, createWhite(pieceOrder[i]));
+            board.get(BLACK_ROW).setPiece(i, createBlack(pieceOrder[i]));
         }
 
     }
 
     public void setPiece(int row, int col, Piece piece) {
-        board.get(row).setPiece(col, piece);  //  Rank의 setPiece() 호출
+        board.get(row).setPiece(col, piece);//  Rank의 setPiece() 호출
     }
 
+    public Piece getPiece(int row, int col){
+        return board.get(row).getPiece(col);
+
+    }
     public Rank getRank(int index) {
         return board.get(index);
     }
+
+
 
 
     public int pieceCount(Piece.Color color, Piece.Type type) {
@@ -80,7 +87,7 @@ public class Board {
 
     public void removePiece(String position) {
         Position pos = new Position(position);
-        setPiece(pos.getRow(), pos.getCol(), Piece.createBlank());
+        setPiece(pos.getRow(), pos.getCol(), createBlank());
     }
 
 

--- a/app/src/main/java/chess/ChessGame.java
+++ b/app/src/main/java/chess/ChessGame.java
@@ -5,21 +5,38 @@ import java.util.Scanner;
 public class ChessGame {
     public static void main(String[] args) {
         Scanner sc = new Scanner(System.in);
+        Board board = new Board();
+        BoardView boardView = new BoardView(board);
+        board.initialize();
 
         while (true) {
-            System.out.println ("Please enter \"start\" to start Ches Game and \"end\" to finish.");
+            System.out.println ("Please enter \"start\" to start Chess Game, \"move <source> <target>\" to move a piece, or \"end\" to finish.");
             String input = sc.nextLine();
+
             if (input.equals("start")) {
-                Board board = new Board();
-                BoardView boardView = new BoardView(board);
-                board.initialize();
                 System.out.println(boardView.showBoard());
-            } else if (input.equals("end")) {
+                continue;
+            }
+            if (input.equals("end")) {
                 break;
-            } else {
-                System.out.println ("Please enter a valid command.");
+            }
+            if (input.startsWith("move")) {
+                movePiece(board, input);
+                System.out.println(boardView.showBoard());
+                continue;
             }
 
+            System.out.println("Please enter a valid command.");
+
+        }
+    }
+
+    public static void movePiece(Board board, String input) {
+        String[] command = input.split(" ");
+        if (command.length == 3) {
+            board.move(command[1], command[2]);
+        } else {
+            System.out.println("Invalid move command. Use: move <source> <target>");
         }
     }
 }

--- a/app/src/main/java/chess/ChessGame.java
+++ b/app/src/main/java/chess/ChessGame.java
@@ -23,8 +23,12 @@ public class ChessGame {
                 break;
             }
             if (input.startsWith("move")) {
-                movePiece(game, input);
-                System.out.println(boardView.showBoard());
+                try {
+                    movePiece(game, input);
+                    System.out.println(boardView.showBoard());
+                } catch (IllegalArgumentException e) {
+                    System.out.println("Error: " + e.getMessage());
+                }
                 continue;
             }
 

--- a/app/src/main/java/chess/ChessGame.java
+++ b/app/src/main/java/chess/ChessGame.java
@@ -3,9 +3,11 @@ package chess;
 import java.util.Scanner;
 
 public class ChessGame {
+
     public static void main(String[] args) {
         Scanner sc = new Scanner(System.in);
         Board board = new Board();
+        Game game = new Game(board);
         BoardView boardView = new BoardView(board);
         board.initialize();
 
@@ -21,7 +23,7 @@ public class ChessGame {
                 break;
             }
             if (input.startsWith("move")) {
-                movePiece(board, input);
+                movePiece(game, input);
                 System.out.println(boardView.showBoard());
                 continue;
             }
@@ -31,10 +33,10 @@ public class ChessGame {
         }
     }
 
-    public static void movePiece(Board board, String input) {
+    public static void movePiece(Game game, String input) {
         String[] command = input.split(" ");
         if (command.length == 3) {
-            board.move(command[1], command[2]);
+            game.move(command[1], command[2]);
         } else {
             System.out.println("Invalid move command. Use: move <source> <target>");
         }

--- a/app/src/main/java/chess/Direction.java
+++ b/app/src/main/java/chess/Direction.java
@@ -1,0 +1,63 @@
+package chess;
+
+import java.util.*;
+
+public enum Direction {
+    NORTH(0, 1),
+    NORTHEAST(1, 1),
+    EAST(1, 0),
+    SOUTHEAST(1, -1),
+    SOUTH(0, -1),
+    SOUTHWEST(-1, -1),
+    WEST(-1, 0),
+    NORTHWEST(-1, 1),
+
+    NNE(1, 2),
+    NNW(-1, 2),
+    SSE(1, -2),
+    SSW(-1, -2),
+    EEN(2, 1),
+    EES(2, -1),
+    WWN(-2, 1),
+    WWS(-2, -1);
+
+    private int xDegree;
+    private int yDegree;
+
+    private Direction(int xDegree, int yDegree) {
+        this.xDegree = xDegree;
+        this.yDegree = yDegree;
+    }
+
+    public int getXDegree() {
+        return xDegree;
+    }
+
+    public int getYDegree() {
+        return yDegree;
+    }
+
+    public static List<Direction> linearDirection() {
+        return Arrays.asList(NORTH, EAST, SOUTH, WEST);
+    }
+
+    public static List<Direction> diagonalDirection() {
+        return Arrays.asList(NORTHEAST, SOUTHEAST, SOUTHWEST, NORTHWEST);
+    }
+
+    public static List<Direction> everyDirection() {
+        return Arrays.asList(NORTH, EAST, SOUTH, WEST, NORTHEAST, SOUTHEAST, SOUTHWEST, NORTHWEST);
+    }
+
+    public static List<Direction> knightDirection() {
+        return Arrays.asList(NNE, NNW, SSE, SSW, EEN, EES, WWN, WWS);
+    }
+
+    public static List<Direction> whitePawnDirection() {
+        return Arrays.asList(NORTH, NORTHEAST, NORTHWEST);
+    }
+
+    public static List<Direction> blackPawnDirection() {
+        return Arrays.asList(SOUTH, SOUTHEAST, SOUTHWEST);
+    }
+}

--- a/app/src/main/java/chess/Direction.java
+++ b/app/src/main/java/chess/Direction.java
@@ -12,6 +12,7 @@ public enum Direction {
     WEST(-1, 0),
     NORTHWEST(-1, 1),
 
+    //Knight 이동 방향
     NNE(1, 2),
     NNW(-1, 2),
     SSE(1, -2),

--- a/app/src/main/java/chess/Game.java
+++ b/app/src/main/java/chess/Game.java
@@ -1,7 +1,6 @@
 package chess;
 
 import pieces.Piece;
-import pieces.Piece.Type;
 
 //move 관련 로직
 public class Game {

--- a/app/src/main/java/chess/Game.java
+++ b/app/src/main/java/chess/Game.java
@@ -3,6 +3,7 @@ package chess;
 import pieces.Piece;
 import pieces.Piece.Type;
 
+//move 관련 로직
 public class Game {
     private final Board board;
 

--- a/app/src/main/java/chess/Game.java
+++ b/app/src/main/java/chess/Game.java
@@ -1,0 +1,24 @@
+package chess;
+
+import pieces.Piece;
+import pieces.Piece.Type;
+
+public class Game {
+    private final Board board;
+
+    public Game(Board board) {
+        this.board = board;
+    }
+
+    public Piece findPiece(String position) {
+        Position pos = new Position(position);
+        return board.getRank(pos.getRow()).getPiece(pos.getCol());
+    }
+
+    public void move(String sourcePosition, String targetPosition) {
+        Position targetPos = new Position(targetPosition);
+        Piece piece = findPiece(sourcePosition);
+        board.removePiece(sourcePosition);
+        board.setPiece(targetPos.getRow(), targetPos.getCol(), piece);
+    }
+}

--- a/app/src/main/java/chess/Game.java
+++ b/app/src/main/java/chess/Game.java
@@ -17,8 +17,14 @@ public class Game {
     }
 
     public void move(String sourcePosition, String targetPosition) {
+        Position sourcePos = new Position(sourcePosition);
         Position targetPos = new Position(targetPosition);
         Piece piece = findPiece(sourcePosition);
+
+        if (!piece.canMove(sourcePos, targetPos, board)) {
+            return;
+        }
+
         board.removePiece(sourcePosition);
         board.setPiece(targetPos.getRow(), targetPos.getCol(), piece);
     }

--- a/app/src/main/java/chess/Game.java
+++ b/app/src/main/java/chess/Game.java
@@ -21,7 +21,7 @@ public class Game {
         Piece piece = findPiece(sourcePosition);
 
         if (!piece.canMove(sourcePos, targetPos, board)) {
-            return;
+            throw new IllegalStateException("Invalid move: " + sourcePosition + " -> " + targetPosition);
         }
 
         board.removePiece(sourcePosition);

--- a/app/src/main/java/chess/Position.java
+++ b/app/src/main/java/chess/Position.java
@@ -30,4 +30,13 @@ public class Position {
         int rowNum = row + 1; // 0-based index → 1-based
         return String.valueOf(colChar) + rowNum;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        Position position = (Position) obj;
+        return row == position.row && col == position.col;
+    }
+
 }

--- a/app/src/main/java/chess/Position.java
+++ b/app/src/main/java/chess/Position.java
@@ -4,9 +4,16 @@ public class Position {
     private final int row;
     private final int col;
 
+    //문자열 이용
     public Position(String position) { //a8
         this.col = position.charAt(0) - 'a'; //a->0, b -> 1, ...
         this.row = Character.getNumericValue(position.charAt(1)) - 1; //출력에서 뒤집어주기
+    }
+
+    //int값 이용 - isPathClear에 필요
+    public Position(int row, int col) {
+        this.row = row;
+        this.col = col;
     }
 
     public int getRow() {
@@ -15,5 +22,12 @@ public class Position {
 
     public int getCol() {
         return col;
+    }
+
+    @Override
+    public String toString() {
+        char colChar = (char) ('a' + col); // 0 → 'a', 1 → 'b', ...
+        int rowNum = row + 1; // 0-based index → 1-based
+        return String.valueOf(colChar) + rowNum;
     }
 }

--- a/app/src/main/java/chess/Rank.java
+++ b/app/src/main/java/chess/Rank.java
@@ -1,6 +1,7 @@
 package chess;
 
 import pieces.Piece;
+import static pieces.PieceFactory.*;
 import java.util.ArrayList;
 
 public class Rank {
@@ -8,7 +9,7 @@ public class Rank {
 
     public Rank() {
         for (int i=0; i < 8; i++) {
-            row.add(Piece.createBlank());
+            row.add(createBlank());
         }
     }
 

--- a/app/src/main/java/chess/ScoreCalculator.java
+++ b/app/src/main/java/chess/ScoreCalculator.java
@@ -7,6 +7,7 @@ import java.util.*;
 
 public class ScoreCalculator {
     private final Board board;
+    private static final int BOARD_SIZE = 8;
 
     public ScoreCalculator(Board board) {
         this.board = board;
@@ -14,10 +15,10 @@ public class ScoreCalculator {
 
     public double calculatePoint(Piece.Color color) {
         double totalScore = 0.0;
-        int[] pawnScores = new int[8];
+        int[] pawnScores = new int[BOARD_SIZE];
 
-        for (int row = 0; row < 8; row++) {  // 세로줄(column) 기준으로 반복
-            for (int col = 0; col < 8; col++) {  // 가로줄(row) 순회
+        for (int row = 0; row < BOARD_SIZE; row++) {  // 세로줄(column) 기준으로 반복
+            for (int col = 0; col < BOARD_SIZE; col++) {  // 가로줄(row) 순회
                 Piece piece = board.getRank(row).getPiece(col);
 
                 if (piece.getColor() == color) {  // 해당 색상의 기물인 경우만 계산
@@ -44,8 +45,8 @@ public class ScoreCalculator {
     public List<Piece> sortByScore(Piece.Color color, boolean desending) {
         List<Piece> sortedPieces = new ArrayList<>();
 
-        for (int row = 0; row < 8; row++) {
-            for (int col = 0; col < 8; col++) {
+        for (int row = 0; row < BOARD_SIZE; row++) {
+            for (int col = 0; col < BOARD_SIZE; col++) {
                 Piece piece = board.getRank(row).getPiece(col);
                 if (piece.getColor() == color) {
                     sortedPieces.add(piece);

--- a/app/src/main/java/pieces/Bishop.java
+++ b/app/src/main/java/pieces/Bishop.java
@@ -1,0 +1,27 @@
+package pieces;
+
+import chess.Board;
+import chess.Direction;
+import chess.Position;
+import java.util.List;
+
+public class Bishop extends Piece {
+    public Bishop(Color color) {
+        super(color, Type.ROOK);
+    }
+
+    @Override
+    public boolean canMove(Position source, Position target, Board board) {
+        List<Direction> allowedDirections = Direction.diagonalDirection(); // 룩은 직선 이동만 가능
+
+        for (Direction direction : allowedDirections) {
+            int rowDiff = target.getRow() - source.getRow();
+            int colDiff = target.getCol() - source.getCol();
+
+            if (rowDiff % direction.getYDegree() == 0 && colDiff % direction.getXDegree() == 0) {
+                return isPathClear(source, target, board) && !isSameColorPiece(target, board);
+            }
+        }
+        return false; //이동 불가능한 경우
+    }
+}

--- a/app/src/main/java/pieces/Bishop.java
+++ b/app/src/main/java/pieces/Bishop.java
@@ -7,21 +7,16 @@ import java.util.List;
 
 public class Bishop extends Piece {
     public Bishop(Color color) {
-        super(color, Type.ROOK);
+        super(color, Type.BISHOP);
     }
 
     @Override
     public boolean canMove(Position source, Position target, Board board) {
-        List<Direction> allowedDirections = Direction.diagonalDirection(); // 룩은 직선 이동만 가능
-
-        for (Direction direction : allowedDirections) {
-            int rowDiff = target.getRow() - source.getRow();
-            int colDiff = target.getCol() - source.getCol();
-
-            if (rowDiff % direction.getYDegree() == 0 && colDiff % direction.getXDegree() == 0) {
-                return isPathClear(source, target, board) && !isSameColorPiece(target, board);
+        for (Direction direction : Direction.diagonalDirection()) {
+            if (canMoveRecursive(source, target, direction, board)) {
+                return true;
             }
         }
-        return false; //이동 불가능한 경우
+        return false;
     }
 }

--- a/app/src/main/java/pieces/Blank.java
+++ b/app/src/main/java/pieces/Blank.java
@@ -1,0 +1,15 @@
+package pieces;
+
+import chess.Board;
+import chess.Position;
+
+public class Blank extends Piece {
+    public Blank() {
+        super(Color.NOCOLOR, Type.NO_PIECE);
+    }
+
+    @Override
+    public boolean canMove(Position source, Position target, Board board) {
+        return false; // 빈 칸은 이동할 수 없음
+    }
+}

--- a/app/src/main/java/pieces/King.java
+++ b/app/src/main/java/pieces/King.java
@@ -19,7 +19,10 @@ public class King extends Piece {
             return false;
         }
 
-        isSameColorPiece(target, board);
+        if (isSameColorPiece(target, board)) {
+            return false;
+
+        }
         return true;
     }
 }

--- a/app/src/main/java/pieces/King.java
+++ b/app/src/main/java/pieces/King.java
@@ -1,0 +1,25 @@
+package pieces;
+
+import chess.Board;
+import chess.Position;
+
+import java.util.List;
+
+public class King extends Piece {
+    public King(Color color) {
+        super(color, Type.KING);
+    }
+
+    @Override
+    public boolean canMove(Position source, Position target, Board board) {
+        int rowDiff = Math.abs(source.getRow() - target.getRow());
+        int colDiff = Math.abs(source.getCol() - target.getCol());
+
+        if (rowDiff > 1 || colDiff > 1) {
+            return false;
+        }
+
+        isSameColorPiece(target, board);
+        return true;
+    }
+}

--- a/app/src/main/java/pieces/King.java
+++ b/app/src/main/java/pieces/King.java
@@ -13,29 +13,13 @@ public class King extends Piece {
 
     @Override
     public boolean canMove(Position source, Position target, Board board) {
-        for (Direction direction : Direction.everyDirection()) {
-            if (canMoveRecursive(source, target, direction, board)) {
-                return true;
-            }
+        int rowDiff = Math.abs(target.getRow() - source.getRow());
+        int colDiff = Math.abs(target.getCol() - source.getCol());
+
+        if (rowDiff <= 1 && colDiff <= 1) {
+            return isPathClear(target, board) && !isSameColorPiece(target, board);
         }
+
         return false;
     }
-
 }
-
-//    @Override
-//    public boolean canMove(Position source, Position target, Board board) {
-//        int rowDiff = Math.abs(source.getRow() - target.getRow());
-//        int colDiff = Math.abs(source.getCol() - target.getCol());
-//
-//        if (rowDiff > 1 || colDiff > 1) {
-//            return false;
-//        }
-//
-//        if (isSameColorPiece(target, board)) {
-//            return false;
-//
-//        }
-//        return true;
-//    }
-//}

--- a/app/src/main/java/pieces/King.java
+++ b/app/src/main/java/pieces/King.java
@@ -1,6 +1,7 @@
 package pieces;
 
 import chess.Board;
+import chess.Direction;
 import chess.Position;
 
 import java.util.List;
@@ -12,17 +13,29 @@ public class King extends Piece {
 
     @Override
     public boolean canMove(Position source, Position target, Board board) {
-        int rowDiff = Math.abs(source.getRow() - target.getRow());
-        int colDiff = Math.abs(source.getCol() - target.getCol());
-
-        if (rowDiff > 1 || colDiff > 1) {
-            return false;
+        for (Direction direction : Direction.everyDirection()) {
+            if (canMoveRecursive(source, target, direction, board)) {
+                return true;
+            }
         }
-
-        if (isSameColorPiece(target, board)) {
-            return false;
-
-        }
-        return true;
+        return false;
     }
+
 }
+
+//    @Override
+//    public boolean canMove(Position source, Position target, Board board) {
+//        int rowDiff = Math.abs(source.getRow() - target.getRow());
+//        int colDiff = Math.abs(source.getCol() - target.getCol());
+//
+//        if (rowDiff > 1 || colDiff > 1) {
+//            return false;
+//        }
+//
+//        if (isSameColorPiece(target, board)) {
+//            return false;
+//
+//        }
+//        return true;
+//    }
+//}

--- a/app/src/main/java/pieces/Knight.java
+++ b/app/src/main/java/pieces/Knight.java
@@ -1,0 +1,27 @@
+package pieces;
+
+import chess.Board;
+import chess.Direction;
+import chess.Position;
+import java.util.List;
+
+public class Knight extends Piece {
+    public Knight(Color color) {
+        super(color, Type.KNIGHT);
+    }
+
+    @Override
+    public boolean canMove(Position source, Position target, Board board) {
+        List<Direction> allowedDirections = Direction.knightDirection();
+
+        for (Direction direction : allowedDirections) {
+            int rowDiff = target.getRow() - source.getRow();
+            int colDiff = target.getCol() - source.getCol();
+
+            if (rowDiff == direction.getYDegree() && colDiff == direction.getXDegree()) {
+                return !isSameColorPiece(target, board);
+            }
+        }
+        return false;
+    }
+}

--- a/app/src/main/java/pieces/Knight.java
+++ b/app/src/main/java/pieces/Knight.java
@@ -12,14 +12,9 @@ public class Knight extends Piece {
 
     @Override
     public boolean canMove(Position source, Position target, Board board) {
-        List<Direction> allowedDirections = Direction.knightDirection();
-
-        for (Direction direction : allowedDirections) {
-            int rowDiff = target.getRow() - source.getRow();
-            int colDiff = target.getCol() - source.getCol();
-
-            if (rowDiff == direction.getYDegree() && colDiff == direction.getXDegree()) {
-                return !isSameColorPiece(target, board);
+        for (Direction direction : Direction.knightDirection()) {
+            if (canMoveRecursive(source, target, direction, board)) {
+                return true;
             }
         }
         return false;

--- a/app/src/main/java/pieces/Pawn.java
+++ b/app/src/main/java/pieces/Pawn.java
@@ -20,7 +20,6 @@ public class Pawn extends Piece {
 
         // 직선 이동 (앞으로 한 칸 또는 두 칸 이동 가능)
         if (colDiff == 0) { // 가로 이동 X (직진만)
-            int maxMove = isFirstMove(source) ? 2 : 1; // 첫 이동이면 2칸 가능
             if (rowDiff == moveDirection * 1 || (rowDiff == moveDirection * 2 && isFirstMove(source))) {
                 return isPathClear(target, board);
             }

--- a/app/src/main/java/pieces/Pawn.java
+++ b/app/src/main/java/pieces/Pawn.java
@@ -1,7 +1,10 @@
 package pieces;
 
 import chess.Board;
+import chess.Direction;
 import chess.Position;
+
+import java.util.List;
 
 public class Pawn extends Piece {
     public Pawn(Color color) {
@@ -12,10 +15,29 @@ public class Pawn extends Piece {
     public boolean canMove(Position source, Position target, Board board) {
         int rowDiff = target.getRow() - source.getRow();
         int colDiff = target.getCol() - source.getCol();
+        int moveDirection = (getColor() == Color.WHITE) ? 1 : -1; // 흰색은 위로(1), 검은색은 아래로(-1)
 
-        // 흰색(White)은 위로 이동해야 하고, 검은색(Black)은 아래로 이동해야 함
-//        int direction = (this.color == Color.WHITE) ? 1 : -1;
-        return true;
+
+        // 직선 이동 (앞으로 한 칸 또는 두 칸 이동 가능)
+        if (colDiff == 0) { // 가로 이동 X (직진만)
+            int maxMove = isFirstMove(source) ? 2 : 1; // 첫 이동이면 2칸 가능
+            if (rowDiff == moveDirection * 1 || (rowDiff == moveDirection * 2 && isFirstMove(source))) {
+                return isPathClear(target, board);
+            }
+        }
+        //  대각선 이동 (공격만 가능)
+        if (Math.abs(colDiff) == 1 && rowDiff == moveDirection) { // 한 칸 대각선 이동
+            if (board.getPiece(target.getRow(), target.getCol()).getType() != Type.NO_PIECE) {
+                return !isSameColorPiece(target, board); // 상대 기물이 있으면 가능
+            }
+        }
+
+        return false;
     }
 
+    //  첫 이동인지 확인
+    private boolean isFirstMove(Position source) {
+        return (getColor() == Color.WHITE && source.getRow() == 1) ||
+                (getColor() == Color.BLACK && source.getRow() == 6);
+    }
 }

--- a/app/src/main/java/pieces/Pawn.java
+++ b/app/src/main/java/pieces/Pawn.java
@@ -1,0 +1,21 @@
+package pieces;
+
+import chess.Board;
+import chess.Position;
+
+public class Pawn extends Piece {
+    public Pawn(Color color) {
+        super(color, Type.PAWN);
+    }
+
+    @Override
+    public boolean canMove(Position source, Position target, Board board) {
+        int rowDiff = target.getRow() - source.getRow();
+        int colDiff = target.getCol() - source.getCol();
+
+        // 흰색(White)은 위로 이동해야 하고, 검은색(Black)은 아래로 이동해야 함
+//        int direction = (this.color == Color.WHITE) ? 1 : -1;
+        return true;
+    }
+
+}

--- a/app/src/main/java/pieces/Piece.java
+++ b/app/src/main/java/pieces/Piece.java
@@ -100,6 +100,9 @@ public class Piece implements Comparable<Piece>  {
         if (this.type == Type.KING) {
             return isValidKingMove(source, target, board);
         }
+        if (this.type == Type.QUEEN) {
+            return isValidQueenMove(source, target, board);
+        }
         return false;
     }
 
@@ -118,6 +121,18 @@ public class Piece implements Comparable<Piece>  {
         if (rowDiff > 1 || colDiff >1 ) {
             throw new RuntimeException("Cannot move to this location.");
         }
+        isSameColorPiece(target, board);
+        return true;
+    }
+
+    private boolean isValidQueenMove(Position source, Position target, Board board) {
+        int rowDiff = Math.abs(source.getRow() - target.getRow());
+        int colDiff =  Math.abs(source.getCol() - target.getCol());
+
+        if (rowDiff != 0 && colDiff != 0) {
+            throw new RuntimeException("Cannot move to this location.");
+        }
+
         isSameColorPiece(target, board);
         return true;
     }

--- a/app/src/main/java/pieces/Piece.java
+++ b/app/src/main/java/pieces/Piece.java
@@ -4,9 +4,9 @@ import chess.Position;
 import chess.Board;
 
 
-public class Piece implements Comparable<Piece>  {
-    private final Color color;
-    private final Type type;
+public abstract class Piece implements Comparable<Piece>  {
+    protected final Color color;
+    protected final Type type;
 
     public enum Color {
         WHITE, BLACK, NOCOLOR;
@@ -43,20 +43,10 @@ public class Piece implements Comparable<Piece>  {
     }
 
 
-    private Piece(Color color, Type type)  {
+    protected Piece(Color color, Type type)  {
         this.color = color;
         this.type = type;
     }
-    public static Piece createWhite(Type type) {
-        return new Piece(Color.WHITE, type);
-    }
-    public static Piece createBlack(Type type) {
-        return new Piece(Color.BLACK, type);
-    }
-    public static Piece createBlank() {
-        return new Piece(Color.NOCOLOR, Type.NO_PIECE);
-    }
-
 
     public char getRepresentation() {
         return color == Color.WHITE? type.getWhiteRepresentation() : type.getBlackRepresentation();
@@ -96,46 +86,39 @@ public class Piece implements Comparable<Piece>  {
         return Double.compare(other.getDefaultPoint(), this.getDefaultPoint());
     }
 
-    public boolean canMove(Position source, Position target, Board board) {
-        if (this.type == Type.KING) {
-            return isValidKingMove(source, target, board);
-        }
-        if (this.type == Type.QUEEN) {
-            return isValidQueenMove(source, target, board);
-        }
-        return false;
-    }
+    //추상 메서드: 하위 클래스(King, Queen 등)에서 반드시 구현해야 함.
+    public abstract boolean canMove(Position source, Position target, Board board);
 
-    protected void isSameColorPiece(Position target, Board board) {
+    protected boolean isSameColorPiece(Position target, Board board) {
         Piece targetPiece = board.getRank(target.getRow()).getPiece(target.getCol());
-        if (targetPiece.getColor() == this.color) {
-            throw new RuntimeException("Cannot move to pieces of the same color.");
-        }
+        return targetPiece.getColor() == this.color;
+
     }
 
-    private boolean isValidKingMove(Position source, Position target, Board board) {
-        int rowDiff = Math.abs(source.getRow() - target.getRow());
-        int colDiff = Math.abs(source.getCol() - target.getCol());
+//    private boolean isValidKingMove(Position source, Position target, Board board) {
+//        int rowDiff = Math.abs(source.getRow() - target.getRow());
+//        int colDiff = Math.abs(source.getCol() - target.getCol());
+//
+//        //King은 모든 방향으로 한 칸만 이동 가능
+//        if (rowDiff > 1 || colDiff >1 ) {
+//            throw new RuntimeException("Cannot move to this location.");
+//        }
+//        isSameColorPiece(target, board);
+//        return true;
+//    }
 
-        //King은 모든 방향으로 한 칸만 이동 가능
-        if (rowDiff > 1 || colDiff >1 ) {
-            throw new RuntimeException("Cannot move to this location.");
-        }
-        isSameColorPiece(target, board);
-        return true;
-    }
+//    private boolean isValidQueenMove(Position source, Position target, Board board) {
+//        int rowDiff = Math.abs(source.getRow() - target.getRow());
+//        int colDiff =  Math.abs(source.getCol() - target.getCol());
+//
+//        if (rowDiff != 0 && colDiff != 0) {
+//            throw new RuntimeException("Cannot move to this location.");
+//        }
+//
+//        isSameColorPiece(target, board);
+//        return true;
+//    }
 
-    private boolean isValidQueenMove(Position source, Position target, Board board) {
-        int rowDiff = Math.abs(source.getRow() - target.getRow());
-        int colDiff =  Math.abs(source.getCol() - target.getCol());
-
-        if (rowDiff != 0 && colDiff != 0) {
-            throw new RuntimeException("Cannot move to this location.");
-        }
-
-        isSameColorPiece(target, board);
-        return true;
-    }
 
 }
 

--- a/app/src/main/java/pieces/Piece.java
+++ b/app/src/main/java/pieces/Piece.java
@@ -103,15 +103,24 @@ public class Piece implements Comparable<Piece>  {
         return false;
     }
 
+    protected void isSameColorPiece(Position target, Board board) {
+        Piece targetPiece = board.getRank(target.getRow()).getPiece(target.getCol());
+        if (targetPiece.getColor() == this.color) {
+            throw new RuntimeException("Cannot move to pieces of the same color.");
+        }
+    }
+
     private boolean isValidKingMove(Position source, Position target, Board board) {
         int rowDiff = Math.abs(source.getRow() - target.getRow());
         int colDiff = Math.abs(source.getCol() - target.getCol());
 
         //King은 모든 방향으로 한 칸만 이동 가능
         if (rowDiff > 1 || colDiff >1 ) {
-            return false;
+            throw new RuntimeException("Cannot move to this location.");
         }
+        isSameColorPiece(target, board);
         return true;
     }
+
 }
 

--- a/app/src/main/java/pieces/Piece.java
+++ b/app/src/main/java/pieces/Piece.java
@@ -7,7 +7,7 @@ import chess.Direction;
 import java.util.List;
 
 
-public abstract class Piece implements Comparable<Piece>  {
+public abstract class Piece implements Comparable<Piece> {
     protected final Color color;
     protected final Type type;
 
@@ -46,13 +46,13 @@ public abstract class Piece implements Comparable<Piece>  {
     }
 
 
-    protected Piece(Color color, Type type)  {
+    protected Piece(Color color, Type type) {
         this.color = color;
         this.type = type;
     }
 
     public char getRepresentation() {
-        return color == Color.WHITE? type.getWhiteRepresentation() : type.getBlackRepresentation();
+        return color == Color.WHITE ? type.getWhiteRepresentation() : type.getBlackRepresentation();
     }
 
     public Color getColor() {
@@ -98,28 +98,32 @@ public abstract class Piece implements Comparable<Piece>  {
 
     }
 
-    //이동 경로에 장애물이 있는지 확인
-    protected boolean isPathClear(Position source, Position target, Board board) {
-        int rowDiff = Math.abs(source.getRow() - target.getRow());
-        int colDiff =  Math.abs(source.getCol() - target.getCol());
+    protected boolean isPathClear(Position position, Board board) {
+        return board.getPiece(position.getRow(), position.getCol()).getType().equals(Type.NO_PIECE);
+    }
 
-        int steps = Math.max(rowDiff, colDiff);
-        int rowStep = Integer.signum(rowDiff); // -1, 0, 1 중 하나
-        int colStep = Integer.signum(colDiff); // -1, 0, 1 중 하나
+    protected boolean canMoveRecursive(Position current, Position target, Direction direction, Board board) {
+        // 한 칸 이동한 새로운 위치 계산
+        Position nextPosition = new Position(
+                current.getRow() + direction.getYDegree(),
+                current.getCol() + direction.getXDegree()
+        );
 
-        int currentRow = source.getRow();
-        int currentCol = source.getCol();
 
-        for (int i = 1; i < steps; i++) { // 중간 경로 확인
-            currentRow += rowStep;
-            currentCol += colStep;
-
-            if (!board.getPiece(currentRow, currentCol).getType().equals(Type.NO_PIECE)) {
-                return false; // 중간에 기물이 있음
-            }
+        if (!board.isValidPosition(nextPosition)) {
+            return false;
         }
-        return true; // 경로가 비어 있음
 
+        // 목표 위치에 도달했으면 같은 색 기물인지 확인 후 이동 가능 여부 반환 -> true
+        if (nextPosition.equals(target)) {
+            return !isSameColorPiece(target, board);
+        }
+
+        // 중간에 기물이 있으면 이동 불가
+        if (!isPathClear(nextPosition, board)) {
+            return false;
+        }
+
+        return canMoveRecursive(nextPosition, target, direction, board);
     }
 }
-

--- a/app/src/main/java/pieces/Piece.java
+++ b/app/src/main/java/pieces/Piece.java
@@ -2,6 +2,9 @@ package pieces;
 
 import chess.Position;
 import chess.Board;
+import chess.Direction;
+
+import java.util.List;
 
 
 public abstract class Piece implements Comparable<Piece>  {
@@ -95,30 +98,28 @@ public abstract class Piece implements Comparable<Piece>  {
 
     }
 
-//    private boolean isValidKingMove(Position source, Position target, Board board) {
-//        int rowDiff = Math.abs(source.getRow() - target.getRow());
-//        int colDiff = Math.abs(source.getCol() - target.getCol());
-//
-//        //King은 모든 방향으로 한 칸만 이동 가능
-//        if (rowDiff > 1 || colDiff >1 ) {
-//            throw new RuntimeException("Cannot move to this location.");
-//        }
-//        isSameColorPiece(target, board);
-//        return true;
-//    }
+    //이동 경로에 장애물이 있는지 확인
+    protected boolean isPathClear(Position source, Position target, Board board) {
+        int rowDiff = Math.abs(source.getRow() - target.getRow());
+        int colDiff =  Math.abs(source.getCol() - target.getCol());
 
-//    private boolean isValidQueenMove(Position source, Position target, Board board) {
-//        int rowDiff = Math.abs(source.getRow() - target.getRow());
-//        int colDiff =  Math.abs(source.getCol() - target.getCol());
-//
-//        if (rowDiff != 0 && colDiff != 0) {
-//            throw new RuntimeException("Cannot move to this location.");
-//        }
-//
-//        isSameColorPiece(target, board);
-//        return true;
-//    }
+        int steps = Math.max(rowDiff, colDiff);
+        int rowStep = Integer.signum(rowDiff); // -1, 0, 1 중 하나
+        int colStep = Integer.signum(colDiff); // -1, 0, 1 중 하나
 
+        int currentRow = source.getRow();
+        int currentCol = source.getCol();
 
+        for (int i = 1; i < steps; i++) { // 중간 경로 확인
+            currentRow += rowStep;
+            currentCol += colStep;
+
+            if (!board.getPiece(currentRow, currentCol).getType().equals(Type.NO_PIECE)) {
+                return false; // 중간에 기물이 있음
+            }
+        }
+        return true; // 경로가 비어 있음
+
+    }
 }
 

--- a/app/src/main/java/pieces/Piece.java
+++ b/app/src/main/java/pieces/Piece.java
@@ -1,5 +1,8 @@
 package pieces;
 
+import chess.Position;
+import chess.Board;
+
 
 public class Piece implements Comparable<Piece>  {
     private final Color color;
@@ -93,5 +96,22 @@ public class Piece implements Comparable<Piece>  {
         return Double.compare(other.getDefaultPoint(), this.getDefaultPoint());
     }
 
+    public boolean canMove(Position source, Position target, Board board) {
+        if (this.type == Type.KING) {
+            return isValidKingMove(source, target, board);
+        }
+        return false;
+    }
+
+    private boolean isValidKingMove(Position source, Position target, Board board) {
+        int rowDiff = Math.abs(source.getRow() - target.getRow());
+        int colDiff = Math.abs(source.getCol() - target.getCol());
+
+        //King은 모든 방향으로 한 칸만 이동 가능
+        if (rowDiff > 1 || colDiff >1 ) {
+            return false;
+        }
+        return true;
+    }
 }
 

--- a/app/src/main/java/pieces/PieceFactory.java
+++ b/app/src/main/java/pieces/PieceFactory.java
@@ -1,0 +1,37 @@
+package pieces;
+
+import pieces.Piece.*;
+
+public class PieceFactory {
+    public static Piece createWhite(Piece.Type type) {
+        return createPiece(Piece.Color.WHITE, type);
+    }
+    public static Piece createBlack(Piece.Type type) {
+        return createPiece(Piece.Color.BLACK, type);
+    }
+
+    public static Piece createBlank() {
+        return new Blank(); // 빈 칸을 나타내는 클래스
+    }
+
+    private static Piece createPiece(Piece.Color color, Piece.Type type) {
+        switch (type) {
+            case PAWN:
+                return new Pawn(color);
+            case ROOK:
+                return new Rook(color);
+            case KNIGHT:
+                return new Knight(color);
+            case BISHOP:
+                return new Bishop(color);
+            case QUEEN:
+                return new Queen(color);
+            case KING:
+                return new King(color);
+            default:
+                throw new IllegalArgumentException("Invalid piece type");
+        }
+    }
+
+
+}

--- a/app/src/main/java/pieces/Queen.java
+++ b/app/src/main/java/pieces/Queen.java
@@ -1,0 +1,25 @@
+package pieces;
+
+import chess.Board;
+import chess.Position;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Queen extends Piece {
+    public Queen(Color color) {
+        super(color, Type.QUEEN);
+    }
+
+    @Override
+    public boolean canMove(Position source, Position target, Board board) {
+        int rowDiff = Math.abs(source.getRow() - target.getRow());
+        int colDiff =  Math.abs(source.getCol() - target.getCol());
+
+        if (rowDiff != 0 && colDiff != 0) {
+            return false;
+        }
+
+        isSameColorPiece(target, board);
+        return true;
+    }
+}

--- a/app/src/main/java/pieces/Queen.java
+++ b/app/src/main/java/pieces/Queen.java
@@ -1,6 +1,7 @@
 package pieces;
 
 import chess.Board;
+import chess.Direction;
 import chess.Position;
 import java.util.ArrayList;
 import java.util.List;
@@ -12,14 +13,20 @@ public class Queen extends Piece {
 
     @Override
     public boolean canMove(Position source, Position target, Board board) {
-        int rowDiff = Math.abs(source.getRow() - target.getRow());
-        int colDiff =  Math.abs(source.getCol() - target.getCol());
+        List<Direction> allowedDirections = new ArrayList<>();
+        allowedDirections.addAll(Direction.linearDirection());
+        allowedDirections.addAll(Direction.diagonalDirection());
 
-        if (rowDiff != 0 && colDiff != 0) {
-            return false;
+        for (Direction direction : allowedDirections) {
+            int rowDiff = target.getRow() - source.getRow();
+            int colDiff = target.getCol() - source.getCol();
+
+
+            if (rowDiff % direction.getYDegree() == 0 && colDiff % direction.getXDegree() == 0) {
+                return isPathClear(source, target, board) && !isSameColorPiece(target, board);
+            }
         }
-
-        isSameColorPiece(target, board);
-        return true;
+        return false;
     }
 }
+

--- a/app/src/main/java/pieces/Queen.java
+++ b/app/src/main/java/pieces/Queen.java
@@ -3,30 +3,20 @@ package pieces;
 import chess.Board;
 import chess.Direction;
 import chess.Position;
-import java.util.ArrayList;
-import java.util.List;
+
 
 public class Queen extends Piece {
     public Queen(Color color) {
-        super(color, Type.QUEEN);
+        super(color, Type.ROOK);
     }
 
     @Override
     public boolean canMove(Position source, Position target, Board board) {
-        List<Direction> allowedDirections = new ArrayList<>();
-        allowedDirections.addAll(Direction.linearDirection());
-        allowedDirections.addAll(Direction.diagonalDirection());
-
-        for (Direction direction : allowedDirections) {
-            int rowDiff = target.getRow() - source.getRow();
-            int colDiff = target.getCol() - source.getCol();
-
-
-            if (rowDiff % direction.getYDegree() == 0 && colDiff % direction.getXDegree() == 0) {
-                return isPathClear(source, target, board) && !isSameColorPiece(target, board);
+        for (Direction direction : Direction.everyDirection()) { // 룩은 직선 이동만 가능
+            if (canMoveRecursive(source, target, direction, board)) {
+                return true;
             }
         }
         return false;
     }
 }
-

--- a/app/src/main/java/pieces/Rook.java
+++ b/app/src/main/java/pieces/Rook.java
@@ -12,7 +12,7 @@ public class Rook extends Piece {
 
     @Override
     public boolean canMove(Position source, Position target, Board board) {
-        for (Direction direction : Direction.linearDirection()) { // 룩은 직선 이동만 가능
+        for (Direction direction : Direction.linearDirection()) {
             if (canMoveRecursive(source, target, direction, board)) {
                 return true;
             }

--- a/app/src/main/java/pieces/Rook.java
+++ b/app/src/main/java/pieces/Rook.java
@@ -12,16 +12,11 @@ public class Rook extends Piece {
 
     @Override
     public boolean canMove(Position source, Position target, Board board) {
-        List<Direction> allowedDirections = Direction.linearDirection(); // 룩은 직선 이동만 가능
-
-        for (Direction direction : allowedDirections) {
-            int rowDiff = target.getRow() - source.getRow();
-            int colDiff = target.getCol() - source.getCol();
-
-            if (rowDiff % direction.getYDegree() == 0 && colDiff % direction.getXDegree() == 0) {
-                return isPathClear(source, target, board) && !isSameColorPiece(target, board);
+        for (Direction direction : Direction.linearDirection()) { // 룩은 직선 이동만 가능
+            if (canMoveRecursive(source, target, direction, board)) {
+                return true;
             }
         }
-        return false; // 이동 불가능한 경우
+        return false;
     }
 }

--- a/app/src/main/java/pieces/Rook.java
+++ b/app/src/main/java/pieces/Rook.java
@@ -1,0 +1,27 @@
+package pieces;
+
+import chess.Board;
+import chess.Direction;
+import chess.Position;
+import java.util.List;
+
+public class Rook extends Piece {
+    public Rook(Color color) {
+        super(color, Type.ROOK);
+    }
+
+    @Override
+    public boolean canMove(Position source, Position target, Board board) {
+        List<Direction> allowedDirections = Direction.linearDirection(); // 룩은 직선 이동만 가능
+
+        for (Direction direction : allowedDirections) {
+            int rowDiff = target.getRow() - source.getRow();
+            int colDiff = target.getCol() - source.getCol();
+
+            if (rowDiff % direction.getYDegree() == 0 && colDiff % direction.getXDegree() == 0) {
+                return isPathClear(source, target, board) && !isSameColorPiece(target, board);
+            }
+        }
+        return false; // 이동 불가능한 경우
+    }
+}

--- a/app/src/test/java/chess/BoardTest.java
+++ b/app/src/test/java/chess/BoardTest.java
@@ -8,11 +8,9 @@ import pieces.Piece.Color;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static utils.StringUtils.appendNewLine;
 
 public class BoardTest {
     private Board board;
-    private BoardView boardView;
 
     @BeforeEach
     public void setup() {
@@ -20,30 +18,6 @@ public class BoardTest {
         boardView = new BoardView(board);
     }
 
-    @Test
-    @DisplayName("기물이 현재 위치에서 다른 위치로 잘 이동하는지 확인")
-    public void move() throws Exception {
-        board.initialize();
-
-        String sourcePosition = "b2";
-        String targetPosition = "b3";
-        board.move(sourcePosition, targetPosition);
-        assertThat(board.findPiece(sourcePosition)).isEqualTo(Piece.createBlank());
-        assertThat(board.findPiece(targetPosition)).isEqualTo(Piece.createWhite(Type.PAWN));
-    }
-
-    @Test
-    @DisplayName("주어진 위치의 기물이 잘 조회되는지 확인")
-    //Unit의 assertThat(A).isEqualTo(B)는 내부적으로 equals()를 자동 호출
-    //equals()는 Piece.java에서 구현
-    public void findPiece() throws Exception {
-        board.initialize();
-        assertThat(board.findPiece("a8")).isEqualTo(Piece.createBlack(Type.ROOK));
-        assertThat(board.findPiece("h8")).isEqualTo(Piece.createBlack(Type.ROOK));
-        assertThat(board.findPiece("a1")).isEqualTo(Piece.createWhite(Type.ROOK));
-        assertThat(board.findPiece("h1")).isEqualTo(Piece.createWhite(Type.ROOK));
-
-    }
 
     @Test
     @DisplayName("초기화된 체스판의 기물 개수 확인")

--- a/app/src/test/java/chess/BoardTest.java
+++ b/app/src/test/java/chess/BoardTest.java
@@ -15,7 +15,6 @@ public class BoardTest {
     @BeforeEach
     public void setup() {
         board = new Board();
-        boardView = new BoardView(board);
     }
 
 

--- a/app/src/test/java/chess/BoardTest.java
+++ b/app/src/test/java/chess/BoardTest.java
@@ -3,6 +3,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import pieces.Piece;
+import pieces.Piece.Type;
+import pieces.Piece.Color;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -19,16 +21,15 @@ public class BoardTest {
     }
 
     @Test
-    @DisplayName("임의의 위치에 기물이 잘 추가되는지 확인")
+    @DisplayName("기물이 현재 위치에서 다른 위치로 잘 이동하는지 확인")
     public void move() throws Exception {
-        board.initializeEmpty();
+        board.initialize();
 
-        String position = "b5";
-        Piece piece = Piece.createBlack(Piece.Type.ROOK);
-        board.move(position, piece);
-
-        assertThat(board.findPiece(position)).isEqualTo(piece);
-        System.out.println(boardView.showBoard());
+        String sourcePosition = "b2";
+        String targetPosition = "b3";
+        board.move(sourcePosition, targetPosition);
+        assertThat(board.findPiece(sourcePosition)).isEqualTo(Piece.createBlank());
+        assertThat(board.findPiece(targetPosition)).isEqualTo(Piece.createWhite(Type.PAWN));
     }
 
     @Test
@@ -37,10 +38,10 @@ public class BoardTest {
     //equals()는 Piece.java에서 구현
     public void findPiece() throws Exception {
         board.initialize();
-        assertThat(board.findPiece("a8")).isEqualTo(Piece.createBlack(Piece.Type.ROOK));
-        assertThat(board.findPiece("h8")).isEqualTo(Piece.createBlack(Piece.Type.ROOK));
-        assertThat(board.findPiece("a1")).isEqualTo(Piece.createWhite(Piece.Type.ROOK));
-        assertThat(board.findPiece("h1")).isEqualTo(Piece.createWhite(Piece.Type.ROOK));
+        assertThat(board.findPiece("a8")).isEqualTo(Piece.createBlack(Type.ROOK));
+        assertThat(board.findPiece("h8")).isEqualTo(Piece.createBlack(Type.ROOK));
+        assertThat(board.findPiece("a1")).isEqualTo(Piece.createWhite(Type.ROOK));
+        assertThat(board.findPiece("h1")).isEqualTo(Piece.createWhite(Type.ROOK));
 
     }
 
@@ -55,11 +56,11 @@ public class BoardTest {
     @DisplayName("특정 기물 개수 확인")
     public void testPieceCount() {
         board.initialize();
-        assertThat(board.pieceCount(Piece.Color.BLACK, Piece.Type.PAWN)).isEqualTo(8);
-        assertThat(board.pieceCount(Piece.Color.WHITE, Piece.Type.PAWN)).isEqualTo(8);
+        assertThat(board.pieceCount(Color.BLACK, Type.PAWN)).isEqualTo(8);
+        assertThat(board.pieceCount(Color.WHITE, Type.PAWN)).isEqualTo(8);
 
-        assertThat(board.pieceCount(Piece.Color.BLACK, Piece.Type.ROOK)).isEqualTo(2);
-        assertThat(board.pieceCount(Piece.Color.WHITE, Piece.Type.ROOK)).isEqualTo(2);
+        assertThat(board.pieceCount(Color.BLACK, Type.ROOK)).isEqualTo(2);
+        assertThat(board.pieceCount(Color.WHITE, Type.ROOK)).isEqualTo(2);
     }
 
 

--- a/app/src/test/java/chess/GameTest.java
+++ b/app/src/test/java/chess/GameTest.java
@@ -21,6 +21,28 @@ public class GameTest {
     }
 
     @Test
+    @DisplayName("king이 잘 움직이는지 확인")
+    public void moveKing() {
+        board.initialize();
+
+        String sourcePosition = "e8";
+        String targetPosition = "d7";
+        game.move(sourcePosition, targetPosition);
+        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlack(Type.KING));
+        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlank());
+    }
+    @Test
+    @DisplayName("king 움직임 예외처리 - 한 칸씩만 이동 가능")
+    public void invalidKingMove() {
+        board.initialize();
+        String sourcePosition = "e8";
+        String targetPosition = "e3";
+        game.move(sourcePosition, targetPosition);
+        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlack(Type.KING));
+        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlank());
+    }
+
+    @Test
     @DisplayName("기물이 현재 위치에서 다른 위치로 잘 이동하는지 확인")
     public void move() throws Exception {
         board.initialize();

--- a/app/src/test/java/chess/GameTest.java
+++ b/app/src/test/java/chess/GameTest.java
@@ -42,6 +42,29 @@ public class GameTest {
         assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlank());
     }
 
+    @Test
+    @DisplayName("Queen 이 잘 움직이는지 확인")
+    public void moveQueen() {
+        board.initialize();
+
+        String sourcePosition = "d8";
+        String targetPosition = "d4";
+        game.move(sourcePosition, targetPosition);
+        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlank());
+        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlack(Type.QUEEN));
+    }
+
+    @Test
+    @DisplayName("Queen 움직임 예외처리 - 직선으로만 이동 가능")
+    public void invalidKingMove() {
+        board.initialize();
+        String sourcePosition = "e8";
+        String targetPosition = "a3";
+        game.move(sourcePosition, targetPosition);
+        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlack(Type.KING));
+        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlank());
+    }
+
 //    @Test
 //    @DisplayName("기물이 현재 위치에서 다른 위치로 잘 이동하는지 확인")
 //    public void move() throws Exception {

--- a/app/src/test/java/chess/GameTest.java
+++ b/app/src/test/java/chess/GameTest.java
@@ -28,8 +28,8 @@ public class GameTest {
         String sourcePosition = "e8";
         String targetPosition = "d7";
         game.move(sourcePosition, targetPosition);
-        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlack(Type.KING));
-        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlank());
+        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlank());
+        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlack(Type.KING));
     }
     @Test
     @DisplayName("king 움직임 예외처리 - 한 칸씩만 이동 가능")
@@ -42,17 +42,17 @@ public class GameTest {
         assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlank());
     }
 
-    @Test
-    @DisplayName("기물이 현재 위치에서 다른 위치로 잘 이동하는지 확인")
-    public void move() throws Exception {
-        board.initialize();
-
-        String sourcePosition = "b2";
-        String targetPosition = "b3";
-        game.move(sourcePosition, targetPosition);
-        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlank());
-        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createWhite(Type.PAWN));
-    }
+//    @Test
+//    @DisplayName("기물이 현재 위치에서 다른 위치로 잘 이동하는지 확인")
+//    public void move() throws Exception {
+//        board.initialize();
+//
+//        String sourcePosition = "b2";
+//        String targetPosition = "b3";
+//        game.move(sourcePosition, targetPosition);
+//        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlank());
+//        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createWhite(Type.PAWN));
+//    }
 
     @Test
     @DisplayName("주어진 위치의 기물이 잘 조회되는지 확인")

--- a/app/src/test/java/chess/GameTest.java
+++ b/app/src/test/java/chess/GameTest.java
@@ -4,9 +4,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import static org.junit.jupiter.api.Assertions.*;
-import pieces.Piece;
-import pieces.Piece.Type;
-
+import pieces.Piece.*;
+import static pieces.PieceFactory.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,8 +29,8 @@ public class GameTest {
         String sourcePosition = "e8";
         String targetPosition = "d7";
         game.move(sourcePosition, targetPosition);
-        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlank());
-        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlack(Type.KING));
+        assertThat(game.findPiece(sourcePosition)).isEqualTo(createBlank());
+        assertThat(game.findPiece(targetPosition)).isEqualTo(createBlack(Type.KING));
     }
     @Test
     @DisplayName("king 움직임 예외처리 - 한 칸씩만 이동 가능")
@@ -56,8 +55,8 @@ public class GameTest {
         String sourcePosition = "d8";
         String targetPosition = "d4";
         game.move(sourcePosition, targetPosition);
-        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlank());
-        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlack(Type.QUEEN));
+        assertThat(game.findPiece(sourcePosition)).isEqualTo(createBlank());
+        assertThat(game.findPiece(targetPosition)).isEqualTo(createBlack(Type.QUEEN));
     }
 
     @Test
@@ -96,10 +95,10 @@ public class GameTest {
     //equals()는 Piece.java에서 구현
     public void findPiece() throws Exception {
         board.initialize();
-        assertThat(game.findPiece("a8")).isEqualTo(Piece.createBlack(Type.ROOK));
-        assertThat(game.findPiece("h8")).isEqualTo(Piece.createBlack(Type.ROOK));
-        assertThat(game.findPiece("a1")).isEqualTo(Piece.createWhite(Type.ROOK));
-        assertThat(game.findPiece("h1")).isEqualTo(Piece.createWhite(Type.ROOK));
+        assertThat(game.findPiece("a8")).isEqualTo(createBlack(Type.ROOK));
+        assertThat(game.findPiece("h8")).isEqualTo(createBlack(Type.ROOK));
+        assertThat(game.findPiece("a1")).isEqualTo(createWhite(Type.ROOK));
+        assertThat(game.findPiece("h1")).isEqualTo(createWhite(Type.ROOK));
 
     }
 }

--- a/app/src/test/java/chess/GameTest.java
+++ b/app/src/test/java/chess/GameTest.java
@@ -3,6 +3,7 @@ package chess;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
+import static org.junit.jupiter.api.Assertions.*;
 import pieces.Piece;
 import pieces.Piece.Type;
 
@@ -24,6 +25,7 @@ public class GameTest {
     @DisplayName("king이 잘 움직이는지 확인")
     public void moveKing() {
         board.initialize();
+        board.removePiece("d7");
 
         String sourcePosition = "e8";
         String targetPosition = "d7";
@@ -37,9 +39,13 @@ public class GameTest {
         board.initialize();
         String sourcePosition = "e8";
         String targetPosition = "e3";
-        game.move(sourcePosition, targetPosition);
-        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlack(Type.KING));
-        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlank());
+        try {
+            game.move(sourcePosition, targetPosition);
+            // 예외가 발생해야 함. 발생하지 않으면 실패
+            fail("움직임 예외 처리 안됨 - 한 칸씩만 이동 가능");
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isEqualTo("Cannot move to this location.");
+        }
     }
 
     @Test
@@ -60,9 +66,13 @@ public class GameTest {
         board.initialize();
         String sourcePosition = "e8";
         String targetPosition = "a3";
-        game.move(sourcePosition, targetPosition);
-        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlack(Type.QUEEN));
-        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlank());
+        try {
+            game.move(sourcePosition, targetPosition);
+            // 예외가 발생해야 함. 발생하지 않으면 실패
+            fail("움직임 예외 처리 안됨 - 직선으로만 이동 가능");
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isEqualTo("Cannot move to this location.");
+        }
     }
 
     @Test
@@ -71,24 +81,14 @@ public class GameTest {
         board.initialize();
         String sourcePosition = "e8";
         String targetPosition = "e7";
-        game.move(sourcePosition, targetPosition);
-        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlack(Type.QUEEN));
-        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlack(Type.PAWN));
+        try {
+            game.move(sourcePosition, targetPosition);
+            // 예외가 발생해야 함. 발생하지 않으면 실패
+            fail("같은 색의 말이 있는 곳으로 이동했음에도 예외 발생 안함.");
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage()).isEqualTo("Cannot move to pieces of the same color.");
+        }
     }
-
-
-
-//    @Test
-//    @DisplayName("기물이 현재 위치에서 다른 위치로 잘 이동하는지 확인")
-//    public void move() throws Exception {
-//        board.initialize();
-//
-//        String sourcePosition = "b2";
-//        String targetPosition = "b3";
-//        game.move(sourcePosition, targetPosition);
-//        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlank());
-//        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createWhite(Type.PAWN));
-//    }
 
     @Test
     @DisplayName("주어진 위치의 기물이 잘 조회되는지 확인")

--- a/app/src/test/java/chess/GameTest.java
+++ b/app/src/test/java/chess/GameTest.java
@@ -56,14 +56,27 @@ public class GameTest {
 
     @Test
     @DisplayName("Queen 움직임 예외처리 - 직선으로만 이동 가능")
-    public void invalidKingMove() {
+    public void invalidQueenMove() {
         board.initialize();
         String sourcePosition = "e8";
         String targetPosition = "a3";
         game.move(sourcePosition, targetPosition);
-        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlack(Type.KING));
+        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlack(Type.QUEEN));
         assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlank());
     }
+
+    @Test
+    @DisplayName("움직임 예외 처리 - 같은 색으로는 이동 물가")
+    public void invalidSameColor() {
+        board.initialize();
+        String sourcePosition = "e8";
+        String targetPosition = "e7";
+        game.move(sourcePosition, targetPosition);
+        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlack(Type.QUEEN));
+        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createBlack(Type.PAWN));
+    }
+
+
 
 //    @Test
 //    @DisplayName("기물이 현재 위치에서 다른 위치로 잘 이동하는지 확인")

--- a/app/src/test/java/chess/GameTest.java
+++ b/app/src/test/java/chess/GameTest.java
@@ -1,0 +1,47 @@
+package chess;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import pieces.Piece;
+import pieces.Piece.Type;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GameTest {
+    private Board board;
+    private Game game;
+
+    @BeforeEach
+    public void setup() {
+        board = new Board();
+        game =  new Game(board);
+
+    }
+
+    @Test
+    @DisplayName("기물이 현재 위치에서 다른 위치로 잘 이동하는지 확인")
+    public void move() throws Exception {
+        board.initialize();
+
+        String sourcePosition = "b2";
+        String targetPosition = "b3";
+        game.move(sourcePosition, targetPosition);
+        assertThat(game.findPiece(sourcePosition)).isEqualTo(Piece.createBlank());
+        assertThat(game.findPiece(targetPosition)).isEqualTo(Piece.createWhite(Type.PAWN));
+    }
+
+    @Test
+    @DisplayName("주어진 위치의 기물이 잘 조회되는지 확인")
+    //Unit의 assertThat(A).isEqualTo(B)는 내부적으로 equals()를 자동 호출
+    //equals()는 Piece.java에서 구현
+    public void findPiece() throws Exception {
+        board.initialize();
+        assertThat(game.findPiece("a8")).isEqualTo(Piece.createBlack(Type.ROOK));
+        assertThat(game.findPiece("h8")).isEqualTo(Piece.createBlack(Type.ROOK));
+        assertThat(game.findPiece("a1")).isEqualTo(Piece.createWhite(Type.ROOK));
+        assertThat(game.findPiece("h1")).isEqualTo(Piece.createWhite(Type.ROOK));
+
+    }
+}

--- a/app/src/test/java/chess/GameTest.java
+++ b/app/src/test/java/chess/GameTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import static org.junit.jupiter.api.Assertions.*;
 import pieces.Piece.*;
 import static pieces.PieceFactory.*;
+import pieces.Piece;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -16,89 +17,188 @@ public class GameTest {
     @BeforeEach
     public void setup() {
         board = new Board();
-        game =  new Game(board);
+        game = new Game(board);
 
     }
-
+    // ✅ PAWN 이동 테스트
     @Test
-    @DisplayName("king이 잘 움직이는지 확인")
-    public void moveKing() {
+    @DisplayName("Pawn 이동 - 한 칸 이동")
+    public void movePawnOneStep() {
         board.initialize();
-        board.removePiece("d7");
 
-        String sourcePosition = "e8";
-        String targetPosition = "d7";
+        String sourcePosition = "d2";
+        String targetPosition = "d3"; // 첫 이동, 한 칸 이동 가능
         game.move(sourcePosition, targetPosition);
+
+        // d2는 비어 있어야 하고, d3에 Pawn이 있어야 함
         assertThat(game.findPiece(sourcePosition)).isEqualTo(createBlank());
-        assertThat(game.findPiece(targetPosition)).isEqualTo(createBlack(Type.KING));
-    }
-    @Test
-    @DisplayName("king 움직임 예외처리 - 한 칸씩만 이동 가능")
-    public void invalidKingMove() {
-        board.initialize();
-        String sourcePosition = "e8";
-        String targetPosition = "e3";
-        try {
-            game.move(sourcePosition, targetPosition);
-            // 예외가 발생해야 함. 발생하지 않으면 실패
-            fail("움직임 예외 처리 안됨 - 한 칸씩만 이동 가능");
-        } catch (RuntimeException e) {
-            assertThat(e.getMessage()).isEqualTo("Cannot move to this location.");
-        }
+        assertThat(game.findPiece(targetPosition)).isEqualTo(createWhite(Piece.Type.PAWN));
     }
 
     @Test
-    @DisplayName("Queen 이 잘 움직이는지 확인")
-    public void moveQueen() {
+    @DisplayName("Pawn 이동 - 첫 이동 2칸 전진")
+    public void movePawnTwoStepsFirstMove() {
         board.initialize();
 
-        String sourcePosition = "d8";
-        String targetPosition = "d4";
+        String sourcePosition = "d2";
+        String targetPosition = "d4"; // 첫 이동, 두 칸 이동 가능
         game.move(sourcePosition, targetPosition);
+
+        // d2는 비어 있어야 하고, d4에 Pawn이 있어야 함
         assertThat(game.findPiece(sourcePosition)).isEqualTo(createBlank());
-        assertThat(game.findPiece(targetPosition)).isEqualTo(createBlack(Type.QUEEN));
+        assertThat(game.findPiece(targetPosition)).isEqualTo(createWhite(Piece.Type.PAWN));
     }
 
     @Test
-    @DisplayName("Queen 움직임 예외처리 - 직선으로만 이동 가능")
-    public void invalidQueenMove() {
+    @DisplayName("Pawn 이동 실패 - 두 칸 이동 후 다시 두 칸 이동 불가")
+    public void movePawnCannotMoveTwoStepsAfterFirstMove() {
         board.initialize();
-        String sourcePosition = "e8";
-        String targetPosition = "a3";
-        try {
+
+        String firstMoveSource = "d2";
+        String firstMoveTarget = "d4";
+        game.move(firstMoveSource, firstMoveTarget); // 첫 이동
+
+        String secondMoveSource = "d4";
+        String secondMoveTarget = "d6"; // 두 번째 이동에서 두 칸 이동 시도
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
+            game.move(secondMoveSource, secondMoveTarget);
+        });
+
+        assertThat(exception.getMessage()).isEqualTo("Invalid move: d4 -> d6");
+    }
+
+
+    // ✅ QUEEN 이동 테스트
+    @Test
+    @DisplayName("Queen 이동 - 직선 이동")
+    public void moveQueenStraight() {
+        board.initialize();
+        board.removePiece("d2");
+
+        String sourcePosition = "d1"; // White Queen
+        String targetPosition = "d4"; // 직선 이동
+
+        game.move(sourcePosition, targetPosition);
+
+        assertThat(game.findPiece(sourcePosition)).isEqualTo(createBlank());
+        assertThat(game.findPiece(targetPosition)).isEqualTo(createWhite(Piece.Type.QUEEN));
+    }
+
+    @Test
+    @DisplayName("Queen 이동 - 대각선 이동")
+    public void moveQueenDiagonal() {
+        board.initialize();
+        board.removePiece("d2");
+        board.removePiece("e2");
+
+        String sourcePosition = "d1"; // White Queen
+        String targetPosition = "h5"; // 대각선 이동
+
+        game.move(sourcePosition, targetPosition);
+
+        assertThat(game.findPiece(sourcePosition)).isEqualTo(createBlank());
+        assertThat(game.findPiece(targetPosition)).isEqualTo(createWhite(Piece.Type.QUEEN));
+    }
+
+    @Test
+    @DisplayName("Queen 이동 실패 - 말도 안 되는 경로")
+    public void moveQueenInvalidPath() {
+        board.initialize();
+        board.removePiece("d2");
+        board.removePiece("e7");
+
+        String sourcePosition = "d1"; // White Queen
+        String targetPosition = "e4"; // 퀸이 이동할 수 없는 경로
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> {
             game.move(sourcePosition, targetPosition);
-            // 예외가 발생해야 함. 발생하지 않으면 실패
-            fail("움직임 예외 처리 안됨 - 직선으로만 이동 가능");
-        } catch (RuntimeException e) {
-            assertThat(e.getMessage()).isEqualTo("Cannot move to this location.");
-        }
+        });
+
+        assertThat(exception.getMessage()).isEqualTo("Invalid move: d1 -> e4");
     }
 
-    @Test
-    @DisplayName("움직임 예외 처리 - 같은 색으로는 이동 물가")
-    public void invalidSameColor() {
-        board.initialize();
-        String sourcePosition = "e8";
-        String targetPosition = "e7";
-        try {
-            game.move(sourcePosition, targetPosition);
-            // 예외가 발생해야 함. 발생하지 않으면 실패
-            fail("같은 색의 말이 있는 곳으로 이동했음에도 예외 발생 안함.");
-        } catch (RuntimeException e) {
-            assertThat(e.getMessage()).isEqualTo("Cannot move to pieces of the same color.");
-        }
-    }
-
-    @Test
-    @DisplayName("주어진 위치의 기물이 잘 조회되는지 확인")
-    //Unit의 assertThat(A).isEqualTo(B)는 내부적으로 equals()를 자동 호출
-    //equals()는 Piece.java에서 구현
-    public void findPiece() throws Exception {
-        board.initialize();
-        assertThat(game.findPiece("a8")).isEqualTo(createBlack(Type.ROOK));
-        assertThat(game.findPiece("h8")).isEqualTo(createBlack(Type.ROOK));
-        assertThat(game.findPiece("a1")).isEqualTo(createWhite(Type.ROOK));
-        assertThat(game.findPiece("h1")).isEqualTo(createWhite(Type.ROOK));
-
-    }
 }
+
+//    @Test
+//    @DisplayName("king이 잘 움직이는지 확인")
+//    public void moveKing() {
+//        board.initialize();
+//        board.removePiece("d7");
+//
+//        String sourcePosition = "e8";
+//        String targetPosition = "d7";
+//        game.move(sourcePosition, targetPosition);
+//        assertThat(game.findPiece(sourcePosition)).isEqualTo(createBlank());
+//        assertThat(game.findPiece(targetPosition)).isEqualTo(createBlack(Type.KING));
+//    }
+//    @Test
+//    @DisplayName("king 움직임 예외처리 - 한 칸씩만 이동 가능")
+//    public void invalidKingMove() {
+//        board.initialize();
+//        String sourcePosition = "e8";
+//        String targetPosition = "e3";
+//        try {
+//            game.move(sourcePosition, targetPosition);
+//            // 예외가 발생해야 함. 발생하지 않으면 실패
+//            fail("움직임 예외 처리 안됨 - 한 칸씩만 이동 가능");
+//        } catch (RuntimeException e) {
+//            assertThat(e.getMessage()).isEqualTo("Cannot move to this location.");
+//        }
+//    }
+//
+//    @Test
+//    @DisplayName("Queen 이 잘 움직이는지 확인")
+//    public void moveQueen() {
+//        board.initialize();
+//
+//        String sourcePosition = "d8";
+//        String targetPosition = "d4";
+//        game.move(sourcePosition, targetPosition);
+//        assertThat(game.findPiece(sourcePosition)).isEqualTo(createBlank());
+//        assertThat(game.findPiece(targetPosition)).isEqualTo(createBlack(Type.QUEEN));
+//    }
+//
+//    @Test
+//    @DisplayName("Queen 움직임 예외처리 - 직선으로만 이동 가능")
+//    public void invalidQueenMove() {
+//        board.initialize();
+//        String sourcePosition = "e8";
+//        String targetPosition = "a3";
+//        try {
+//            game.move(sourcePosition, targetPosition);
+//            // 예외가 발생해야 함. 발생하지 않으면 실패
+//            fail("움직임 예외 처리 안됨 - 직선으로만 이동 가능");
+//        } catch (RuntimeException e) {
+//            assertThat(e.getMessage()).isEqualTo("Cannot move to this location.");
+//        }
+//    }
+//
+//    @Test
+//    @DisplayName("움직임 예외 처리 - 같은 색으로는 이동 물가")
+//    public void invalidSameColor() {
+//        board.initialize();
+//        String sourcePosition = "e8";
+//        String targetPosition = "e7";
+//        try {
+//            game.move(sourcePosition, targetPosition);
+//            // 예외가 발생해야 함. 발생하지 않으면 실패
+//            fail("같은 색의 말이 있는 곳으로 이동했음에도 예외 발생 안함.");
+//        } catch (RuntimeException e) {
+//            assertThat(e.getMessage()).isEqualTo("Cannot move to pieces of the same color.");
+//        }
+//    }
+//
+//    @Test
+//    @DisplayName("주어진 위치의 기물이 잘 조회되는지 확인")
+//    //Unit의 assertThat(A).isEqualTo(B)는 내부적으로 equals()를 자동 호출
+//    //equals()는 Piece.java에서 구현
+//    public void findPiece() throws Exception {
+//        board.initialize();
+//        assertThat(game.findPiece("a8")).isEqualTo(createBlack(Type.ROOK));
+//        assertThat(game.findPiece("h8")).isEqualTo(createBlack(Type.ROOK));
+//        assertThat(game.findPiece("a1")).isEqualTo(createWhite(Type.ROOK));
+//        assertThat(game.findPiece("h1")).isEqualTo(createWhite(Type.ROOK));
+//
+//    }
+//}

--- a/app/src/test/java/chess/ScoreCalculatorTest.java
+++ b/app/src/test/java/chess/ScoreCalculatorTest.java
@@ -24,15 +24,15 @@ public class ScoreCalculatorTest {
     public void calculatePoint() throws Exception {
         board.initializeEmpty();
 
-        addPiece("b6", Piece.createBlack(Piece.Type.PAWN));
-        addPiece("e6", Piece.createBlack(Piece.Type.QUEEN));
-        addPiece("b8", Piece.createBlack(Piece.Type.KING));
-        addPiece("c8", Piece.createBlack(Piece.Type.ROOK));
+        board.addPiece("b6", Piece.createBlack(Piece.Type.PAWN));
+        board.addPiece("e6", Piece.createBlack(Piece.Type.QUEEN));
+        board.addPiece("b8", Piece.createBlack(Piece.Type.KING));
+        board.addPiece("c8", Piece.createBlack(Piece.Type.ROOK));
 
-        addPiece("f2", Piece.createWhite(Piece.Type.PAWN));
-        addPiece("g2", Piece.createWhite(Piece.Type.PAWN));
-        addPiece("e1", Piece.createWhite(Piece.Type.ROOK));
-        addPiece("f1", Piece.createWhite(Piece.Type.KING));
+        board.addPiece("f2", Piece.createWhite(Piece.Type.PAWN));
+        board.addPiece("g2", Piece.createWhite(Piece.Type.PAWN));
+        board.addPiece("e1", Piece.createWhite(Piece.Type.ROOK));
+        board.addPiece("f1", Piece.createWhite(Piece.Type.KING));
 
         assertThat(scoreCalculator.calculatePoint(Piece.Color.BLACK)).isEqualTo(15.0);
         assertThat(scoreCalculator.calculatePoint(Piece.Color.WHITE)).isEqualTo(7.0);
@@ -43,28 +43,25 @@ public class ScoreCalculatorTest {
     public void calculatePoint_pawnsInSameColumn() {
         board.initializeEmpty();
 
-        addPiece("a2", Piece.createWhite(Piece.Type.PAWN));
-        addPiece("a3", Piece.createWhite(Piece.Type.PAWN)); // 같은 col: 0.5+0.5
+        board.addPiece("a2", Piece.createWhite(Piece.Type.PAWN));
+        board.addPiece("a3", Piece.createWhite(Piece.Type.PAWN)); // 같은 col: 0.5+0.5
 
-        addPiece("b2", Piece.createWhite(Piece.Type.PAWN)); // 1.0
+        board.addPiece("b2", Piece.createWhite(Piece.Type.PAWN)); // 1.0
 
         assertThat(scoreCalculator.calculatePoint(Piece.Color.WHITE)).isEqualTo(2);
 
     }
-    
-    private void addPiece(String position, Piece piece) {
-        board.move(position, piece);
-    }
+
 
     @Test
     @DisplayName("체스판 내 기물 정렬")
     public void sortPiecesbyScore() {
         board.initializeEmpty();
 
-        addPiece("b6", Piece.createBlack(Piece.Type.PAWN));  // PAWN(1.0)
-        addPiece("e6", Piece.createBlack(Piece.Type.QUEEN));  // Queen (9.0)
-        addPiece("b8", Piece.createBlack(Piece.Type.KING));  // KING (0.0)
-        addPiece("c8", Piece.createBlack(Piece.Type.ROOK));  // Rook (5.0)
+        board.addPiece("b6", Piece.createBlack(Piece.Type.PAWN));  // PAWN(1.0)
+        board.addPiece("e6", Piece.createBlack(Piece.Type.QUEEN));  // Queen (9.0)
+        board.addPiece("b8", Piece.createBlack(Piece.Type.KING));  // KING (0.0)
+        board.addPiece("c8", Piece.createBlack(Piece.Type.ROOK));  // Rook (5.0)
 
         List<Piece> sortedBlackPieces = scoreCalculator.sortByScore(Piece.Color.BLACK, true);
 
@@ -73,10 +70,10 @@ public class ScoreCalculatorTest {
         assertThat(sortedBlackPieces.get(2).getType()).isEqualTo(Piece.Type.PAWN);
         assertThat(sortedBlackPieces.get(3).getType()).isEqualTo(Piece.Type.KING);
 
-        addPiece("f2", Piece.createWhite(Piece.Type.PAWN));  // PAWN(1.0)
-        addPiece("g2", Piece.createWhite(Piece.Type.PAWN));  //  PAWN(1.0)
-        addPiece("e1", Piece.createWhite(Piece.Type.ROOK));  //  Rook (5.0)
-        addPiece("f1", Piece.createWhite(Piece.Type.KING));  //  KING (0.0)
+        board.addPiece("f2", Piece.createWhite(Piece.Type.PAWN));  // PAWN(1.0)
+        board.addPiece("g2", Piece.createWhite(Piece.Type.PAWN));  //  PAWN(1.0)
+        board.addPiece("e1", Piece.createWhite(Piece.Type.ROOK));  //  Rook (5.0)
+        board.addPiece("f1", Piece.createWhite(Piece.Type.KING));  //  KING (0.0)
 
         List<Piece> sortedWhitePieces = scoreCalculator.sortByScore(Piece.Color.WHITE, true);
 

--- a/app/src/test/java/chess/ScoreCalculatorTest.java
+++ b/app/src/test/java/chess/ScoreCalculatorTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import pieces.Piece;
+import pieces.Piece.*;
+import static pieces.PieceFactory.*;
 
 import java.util.List;
 
@@ -24,18 +26,18 @@ public class ScoreCalculatorTest {
     public void calculatePoint() throws Exception {
         board.initializeEmpty();
 
-        board.addPiece("b6", Piece.createBlack(Piece.Type.PAWN));
-        board.addPiece("e6", Piece.createBlack(Piece.Type.QUEEN));
-        board.addPiece("b8", Piece.createBlack(Piece.Type.KING));
-        board.addPiece("c8", Piece.createBlack(Piece.Type.ROOK));
+        board.addPiece("b6", createBlack(Type.PAWN));
+        board.addPiece("e6", createBlack(Type.QUEEN));
+        board.addPiece("b8", createBlack(Type.KING));
+        board.addPiece("c8", createBlack(Type.ROOK));
 
-        board.addPiece("f2", Piece.createWhite(Piece.Type.PAWN));
-        board.addPiece("g2", Piece.createWhite(Piece.Type.PAWN));
-        board.addPiece("e1", Piece.createWhite(Piece.Type.ROOK));
-        board.addPiece("f1", Piece.createWhite(Piece.Type.KING));
+        board.addPiece("f2", createWhite(Type.PAWN));
+        board.addPiece("g2", createWhite(Type.PAWN));
+        board.addPiece("e1", createWhite(Type.ROOK));
+        board.addPiece("f1", createWhite(Type.KING));
 
-        assertThat(scoreCalculator.calculatePoint(Piece.Color.BLACK)).isEqualTo(15.0);
-        assertThat(scoreCalculator.calculatePoint(Piece.Color.WHITE)).isEqualTo(7.0);
+        assertThat(scoreCalculator.calculatePoint(Color.BLACK)).isEqualTo(15.0);
+        assertThat(scoreCalculator.calculatePoint(Color.WHITE)).isEqualTo(7.0);
     }
 
     @Test
@@ -43,12 +45,12 @@ public class ScoreCalculatorTest {
     public void calculatePoint_pawnsInSameColumn() {
         board.initializeEmpty();
 
-        board.addPiece("a2", Piece.createWhite(Piece.Type.PAWN));
-        board.addPiece("a3", Piece.createWhite(Piece.Type.PAWN)); // 같은 col: 0.5+0.5
+        board.addPiece("a2", createWhite(Type.PAWN));
+        board.addPiece("a3", createWhite(Type.PAWN)); // 같은 col: 0.5+0.5
 
-        board.addPiece("b2", Piece.createWhite(Piece.Type.PAWN)); // 1.0
+        board.addPiece("b2", createWhite(Type.PAWN)); // 1.0
 
-        assertThat(scoreCalculator.calculatePoint(Piece.Color.WHITE)).isEqualTo(2);
+        assertThat(scoreCalculator.calculatePoint(Color.WHITE)).isEqualTo(2);
 
     }
 
@@ -58,29 +60,29 @@ public class ScoreCalculatorTest {
     public void sortPiecesbyScore() {
         board.initializeEmpty();
 
-        board.addPiece("b6", Piece.createBlack(Piece.Type.PAWN));  // PAWN(1.0)
-        board.addPiece("e6", Piece.createBlack(Piece.Type.QUEEN));  // Queen (9.0)
-        board.addPiece("b8", Piece.createBlack(Piece.Type.KING));  // KING (0.0)
-        board.addPiece("c8", Piece.createBlack(Piece.Type.ROOK));  // Rook (5.0)
+        board.addPiece("b6", createBlack(Type.PAWN));  // PAWN(1.0)
+        board.addPiece("e6", createBlack(Type.QUEEN));  // Queen (9.0)
+        board.addPiece("b8", createBlack(Type.KING));  // KING (0.0)
+        board.addPiece("c8", createBlack(Type.ROOK));  // Rook (5.0)
 
-        List<Piece> sortedBlackPieces = scoreCalculator.sortByScore(Piece.Color.BLACK, true);
+        List<Piece> sortedBlackPieces = scoreCalculator.sortByScore(Color.BLACK, true);
 
-        assertThat(sortedBlackPieces.get(0).getType()).isEqualTo(Piece.Type.QUEEN);
-        assertThat(sortedBlackPieces.get(1).getType()).isEqualTo(Piece.Type.ROOK);
-        assertThat(sortedBlackPieces.get(2).getType()).isEqualTo(Piece.Type.PAWN);
-        assertThat(sortedBlackPieces.get(3).getType()).isEqualTo(Piece.Type.KING);
+        assertThat(sortedBlackPieces.get(0).getType()).isEqualTo(Type.QUEEN);
+        assertThat(sortedBlackPieces.get(1).getType()).isEqualTo(Type.ROOK);
+        assertThat(sortedBlackPieces.get(2).getType()).isEqualTo(Type.PAWN);
+        assertThat(sortedBlackPieces.get(3).getType()).isEqualTo(Type.KING);
 
-        board.addPiece("f2", Piece.createWhite(Piece.Type.PAWN));  // PAWN(1.0)
-        board.addPiece("g2", Piece.createWhite(Piece.Type.PAWN));  //  PAWN(1.0)
-        board.addPiece("e1", Piece.createWhite(Piece.Type.ROOK));  //  Rook (5.0)
-        board.addPiece("f1", Piece.createWhite(Piece.Type.KING));  //  KING (0.0)
+        board.addPiece("f2", createWhite(Type.PAWN));  // PAWN(1.0)
+        board.addPiece("g2", createWhite(Type.PAWN));  //  PAWN(1.0)
+        board.addPiece("e1", createWhite(Type.ROOK));  //  Rook (5.0)
+        board.addPiece("f1", createWhite(Type.KING));  //  KING (0.0)
 
         List<Piece> sortedWhitePieces = scoreCalculator.sortByScore(Piece.Color.WHITE, true);
 
-        assertThat(sortedWhitePieces.get(0).getType()).isEqualTo(Piece.Type.ROOK);
-        assertThat(sortedWhitePieces.get(1).getType()).isEqualTo(Piece.Type.PAWN);
-        assertThat(sortedWhitePieces.get(2).getType()).isEqualTo(Piece.Type.PAWN);
-        assertThat(sortedWhitePieces.get(3).getType()).isEqualTo(Piece.Type.KING);
+        assertThat(sortedWhitePieces.get(0).getType()).isEqualTo(Type.ROOK);
+        assertThat(sortedWhitePieces.get(1).getType()).isEqualTo(Type.PAWN);
+        assertThat(sortedWhitePieces.get(2).getType()).isEqualTo(Type.PAWN);
+        assertThat(sortedWhitePieces.get(3).getType()).isEqualTo(Type.KING);
 
     }
 

--- a/app/src/test/java/pieces/BishopTest.java
+++ b/app/src/test/java/pieces/BishopTest.java
@@ -1,0 +1,45 @@
+package pieces;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.assertj.core.api.Assertions.assertThat;
+import chess.*;
+
+public class BishopTest {
+    private Board board;
+    
+    @BeforeEach
+    public void setup() {
+        board = new Board();
+    }
+    @Test
+    @DisplayName("Bishop 움직임 확인 - 대각선")
+    public void moveBishop_Straight() {
+        board.initialize();
+        board.removePiece("e7");
+
+        Position source = new Position("f8");
+        Position target = new Position("c5");
+        Piece Bishop = board.getPiece(source.getRow(), source.getCol());
+
+
+        assertThat(Bishop.canMove(source, target, board)).isTrue();
+
+    }
+
+    @Test
+    @DisplayName("Bishop 움직임 예외처리 - 직선")
+    public void moveBishop_Diagonal() {
+        board.initialize();
+        board.removePiece("f7");
+
+        Position source = new Position("f8");
+        Position target = new Position("f5");
+        Piece Bishop = board.getPiece(source.getRow(), source.getCol());
+
+
+        assertThat(Bishop.canMove(source, target, board)).isFalse();
+
+    }
+}

--- a/app/src/test/java/pieces/KingTest.java
+++ b/app/src/test/java/pieces/KingTest.java
@@ -12,12 +12,12 @@ public class KingTest {
     @BeforeEach
     public void setup() {
         board = new Board();
-        board.initialize();
     }
 
     @Test
     @DisplayName("King움직임 확인 - 8방향으로 한 칸만 움직일 수 있음")
     public void moveKing() {
+        board.initialize();
         board.removePiece("e7"); // 이동할 위치를 제거 -> 나중에 PAWN 구현하면 PAWN 이동시키기
         Position source = new Position("e8");
         Position target = new Position("e7");
@@ -30,6 +30,8 @@ public class KingTest {
     @Test
     @DisplayName("King움직임 예외 처리 - 한 칸 이상 움지일 수 없음")
     public void invalidKingMove() {
+        board.initialize();
+        board.removePiece("e7");
         Position source = new Position("e8");
         Position target = new Position("e6"); // 두 칸 이동
         Piece king = board.getPiece(source.getRow(), source.getCol());
@@ -41,6 +43,7 @@ public class KingTest {
     @Test
     @DisplayName("King움직임 예외 처리 - 목적지에 같은 색 기물 있으면 이동 불가")
     public void kingCannotMoveToSameColorPiece() {
+        board.initialize();
         Position source = new Position("e8");
         Position target = new Position("e7"); // 같은 색 기물
         Piece king = board.getPiece(source.getRow(), source.getCol());

--- a/app/src/test/java/pieces/KingTest.java
+++ b/app/src/test/java/pieces/KingTest.java
@@ -1,0 +1,49 @@
+package pieces;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.assertj.core.api.Assertions.assertThat;
+import chess.*;
+
+public class KingTest {
+    private Board board;
+
+    @BeforeEach
+    public void setup() {
+        board = new Board();
+        board.initialize();
+    }
+
+    @Test
+    @DisplayName("King이 한 칸씩 이동할 수 있어야 한다")
+    public void moveKingOneStep() {
+        board.removePiece("e7"); // 이동할 위치를 비움
+        Position source = new Position("e8");
+        Position target = new Position("e7");
+        Piece king = board.getPiece(source.getRow(), source.getCol());
+
+        //king이 이돌할 수 있는지만 검증 (실제 이동 x)
+        assertThat(king.canMove(source, target, board)).isTrue();
+    }
+
+    @Test
+    @DisplayName("King은 한 칸 이상 이동할 수 없다")
+    public void invalidKingMove() {
+        Position source = new Position("e8");
+        Position target = new Position("e6"); // 두 칸 이동 (잘못된 이동)
+        Piece king = board.getPiece(source.getRow(), source.getCol());
+
+        assertThat(king.canMove(source, target, board)).isFalse();
+    }
+
+    @Test
+    @DisplayName("King이 같은 색 기물이 있는 곳으로 이동할 수 없다")
+    public void kingCannotMoveToSameColorPiece() {
+        Position source = new Position("e8");
+        Position target = new Position("e7"); // 이미 같은 색 기물이 있음
+        Piece king = board.getPiece(source.getRow(), source.getCol());
+
+        assertThat(king.canMove(source, target, board)).isFalse();
+    }
+}

--- a/app/src/test/java/pieces/KingTest.java
+++ b/app/src/test/java/pieces/KingTest.java
@@ -16,32 +16,33 @@ public class KingTest {
     }
 
     @Test
-    @DisplayName("King이 한 칸씩 이동할 수 있어야 한다")
-    public void moveKingOneStep() {
-        board.removePiece("e7"); // 이동할 위치를 비움
+    @DisplayName("King움직임 확인 - 8방향으로 한 칸만 움직일 수 있음")
+    public void moveKing() {
+        board.removePiece("e7"); // 이동할 위치를 제거 -> 나중에 PAWN 구현하면 PAWN 이동시키기
         Position source = new Position("e8");
         Position target = new Position("e7");
         Piece king = board.getPiece(source.getRow(), source.getCol());
 
-        //king이 이돌할 수 있는지만 검증 (실제 이동 x)
+        //king이 이돌할 수 있는지만 검증 (실제 이동 x, canMove만 확인)
         assertThat(king.canMove(source, target, board)).isTrue();
     }
 
     @Test
-    @DisplayName("King은 한 칸 이상 이동할 수 없다")
+    @DisplayName("King움직임 예외 처리 - 한 칸 이상 움지일 수 없음")
     public void invalidKingMove() {
         Position source = new Position("e8");
-        Position target = new Position("e6"); // 두 칸 이동 (잘못된 이동)
+        Position target = new Position("e6"); // 두 칸 이동
         Piece king = board.getPiece(source.getRow(), source.getCol());
 
         assertThat(king.canMove(source, target, board)).isFalse();
     }
 
+    //이 예외처리는 GameMove에서 해도 될 것 같음.
     @Test
-    @DisplayName("King이 같은 색 기물이 있는 곳으로 이동할 수 없다")
+    @DisplayName("King움직임 예외 처리 - 목적지에 같은 색 기물 있으면 이동 불가")
     public void kingCannotMoveToSameColorPiece() {
         Position source = new Position("e8");
-        Position target = new Position("e7"); // 이미 같은 색 기물이 있음
+        Position target = new Position("e7"); // 같은 색 기물
         Piece king = board.getPiece(source.getRow(), source.getCol());
 
         assertThat(king.canMove(source, target, board)).isFalse();

--- a/app/src/test/java/pieces/KnightTest.java
+++ b/app/src/test/java/pieces/KnightTest.java
@@ -1,0 +1,32 @@
+package pieces;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.assertj.core.api.Assertions.assertThat;
+import chess.*;
+
+public class KnightTest {
+    private Board board;
+
+    @BeforeEach
+    public void setup() {
+        board = new Board();
+    }
+
+    @Test
+    @DisplayName("Knight 움직임 확인")
+    public void moveKnight_Straight() {
+        board.initialize();
+        board.removePiece("b7");
+        board.removePiece("c7");
+
+        Position source = new Position("b8");
+        Position target = new Position("c6");
+        Piece Knight = board.getPiece(source.getRow(), source.getCol());
+
+
+        assertThat(Knight.canMove(source, target, board)).isTrue();
+
+    }
+}

--- a/app/src/test/java/pieces/PawnTest.java
+++ b/app/src/test/java/pieces/PawnTest.java
@@ -1,0 +1,76 @@
+package pieces;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import chess.*;
+
+public class PawnTest {
+    private Board board;
+
+    @BeforeEach
+    public void setup() {
+        board = new Board();
+
+    }
+
+    @Test
+    @DisplayName("Pawn 움직임 확인 - 첫 이동 2칸 전진")
+    public void movePawn_TwoStepsFirstMove() {
+        board.initialize();
+        Position source = new Position("d2");
+        Position target = new Position("d4"); // 첫 이동, 두 칸 이동 가능
+        Piece pawn = board.getPiece(source.getRow(), source.getCol());
+
+        assertThat(pawn.canMove(source, target, board)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Pawn 움직임 확인 - 한 칸 전진")
+    public void movePawn_OneStepForward() {
+        board.initialize();
+        Position source = new Position("d2");
+        Position target = new Position("d3"); // 한 칸 이동
+        Piece pawn = board.getPiece(source.getRow(), source.getCol());
+
+        assertThat(pawn.canMove(source, target, board)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Pawn 움직임 확인 - 첫 이동 아니면(행으로 판별) 두 칸 이동 불가")
+    public void movePawn_CannotMoveTwoStepsAfterFirstMove() {
+        board.initialize();
+        board.addPiece("d3", new Pawn(Piece.Color.BLACK));
+        Position source = new Position("d3");
+        Position target = new Position("d5"); // 한 칸 이동
+        Piece pawn = board.getPiece(source.getRow(), source.getCol());
+
+        assertThat(pawn.canMove(source, target, board)).isFalse();
+    }
+
+    @Test
+    @DisplayName("Pawn 공격 확인 - 대각선 이동 가능")
+    public void movePawn_DiagonalCapture() {
+        board.initialize();
+        board.addPiece("e3", new Pawn(Piece.Color.BLACK)); // 상대 기물 배치
+        Position source = new Position("d2");
+        Position target = new Position("e3"); // 대각선 이동(공격)
+        Piece pawn = board.getPiece(source.getRow(), source.getCol());
+
+        assertThat(pawn.canMove(source, target, board)).isTrue();
+    }
+
+    @Test
+    @DisplayName("Pawn 공격 불가 - 같은 색 기물이 있으면 대각선 이동 불가")
+    public void movePawn_CannotCaptureSameColor() {
+        board.initialize();
+        board.addPiece("e3", new Pawn(Piece.Color.WHITE)); // 같은 색 기물 배치
+        Position source = new Position("d2");
+        Position target = new Position("e3"); // 대각선 이동(같은 색 기물 공격 불가)
+        Piece pawn = board.getPiece(source.getRow(), source.getCol());
+
+        assertThat(pawn.canMove(source, target, board)).isFalse();
+    }
+}
+

--- a/app/src/test/java/pieces/PieceTest.java
+++ b/app/src/test/java/pieces/PieceTest.java
@@ -1,7 +1,7 @@
 package pieces;
 
 import pieces.Piece.Type;
-//import static pieces.Piece.Type.*; 사용해서 간결하게 하는게 좋은 방법?
+import static pieces.PieceFactory.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,14 +21,14 @@ public class PieceTest {
     @Test
     @DisplayName("모든 기물의 색과 출력문자를 검증한다")
     public void create_piece() {
-        verifyPiece(Piece.createWhite(Type.PAWN), Piece.createBlack(Type.PAWN), Type.PAWN);
-        verifyPiece(Piece.createWhite(Type.KNIGHT), Piece.createBlack(Type.KNIGHT), Type.KNIGHT);
-        verifyPiece(Piece.createWhite(Type.ROOK), Piece.createBlack(Type.ROOK), Type.ROOK);
-        verifyPiece(Piece.createWhite(Type.BISHOP), Piece.createBlack(Type.BISHOP), Type.BISHOP);
-        verifyPiece(Piece.createWhite(Type.QUEEN), Piece.createBlack(Type.QUEEN), Type.QUEEN);
-        verifyPiece(Piece.createWhite(Type.KING), Piece.createBlack(Type.KING), Type.KING);
+        verifyPiece(createWhite(Type.PAWN), createBlack(Type.PAWN), Type.PAWN);
+        verifyPiece(createWhite(Type.KNIGHT), createBlack(Type.KNIGHT), Type.KNIGHT);
+        verifyPiece(createWhite(Type.ROOK), createBlack(Type.ROOK), Type.ROOK);
+        verifyPiece(createWhite(Type.BISHOP), createBlack(Type.BISHOP), Type.BISHOP);
+        verifyPiece(createWhite(Type.QUEEN), createBlack(Type.QUEEN), Type.QUEEN);
+        verifyPiece(createWhite(Type.KING), createBlack(Type.KING), Type.KING);
 
-        Piece blank = Piece.createBlank();
+        Piece blank = createBlank();
         assertFalse(blank.isWhite());
         assertFalse(blank.isBlack());
         assertThat(blank.getType()).isEqualTo(Type.NO_PIECE);

--- a/app/src/test/java/pieces/QueenTest.java
+++ b/app/src/test/java/pieces/QueenTest.java
@@ -1,0 +1,61 @@
+package pieces;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.assertj.core.api.Assertions.assertThat;
+import chess.*;
+
+public class QueenTest {
+    private Board board;
+
+    @BeforeEach
+    public void setup() {
+        board = new Board();
+    }
+
+    @Test
+    @DisplayName("Queen 움직임 확인 - 직선")
+    public void moveQueen_Straight() {
+        board.initialize();
+        board.removePiece("d7"); //직선에 있는 PAWN 제거
+
+        Position source = new Position("d8");
+        Position target = new Position("d5");
+        Piece Queen = board.getPiece(source.getRow(), source.getCol());
+
+
+        assertThat(Queen.canMove(source, target, board)).isTrue();
+
+    }
+
+    @Test
+    @DisplayName("Queen 움직임 확인 - 대각선")
+    public void moveQueen_diagonal() {
+        board.initialize();
+        board.removePiece("c7"); //직선에 있는 PAWN 제거
+
+        Position source = new Position("d8");
+        Position target = new Position("b6");
+        Piece Queen = board.getPiece(source.getRow(), source.getCol());
+
+
+        assertThat(Queen.canMove(source, target, board)).isTrue();
+
+    }
+    @Test
+    @DisplayName("Queen 움직임 예외처리 - 대각과 직선 아닌 곳")
+    public void moveQueen_exception() {
+        board.initialize();
+        board.removePiece("d7"); //직선에 있는 PAWN 제거
+
+        Position source = new Position("d8");
+        Position target = new Position("b5");
+        Piece Queen = board.getPiece(source.getRow(), source.getCol());
+
+
+        assertThat(Queen.canMove(source, target, board)).isFalse();
+
+    }
+}
+

--- a/app/src/test/java/pieces/RookTest.java
+++ b/app/src/test/java/pieces/RookTest.java
@@ -1,0 +1,63 @@
+package pieces;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import static org.assertj.core.api.Assertions.assertThat;
+import chess.*;
+
+public class RookTest {
+    private Board board;
+
+    @BeforeEach
+    public void setup() {
+        board = new Board();
+    }
+
+    @Test
+    @DisplayName("Rook 움직임 확인 - 직선")
+    public void moveRook_Straight() {
+        board.initialize();
+        board.removePiece("a7"); //직선에 있는 PAWN 제거
+
+        Position source = new Position("a8");
+        Position target = new Position("a2");
+        Piece Rook = board.getPiece(source.getRow(), source.getCol());
+
+
+        assertThat(Rook.canMove(source, target, board)).isTrue();
+
+    }
+
+    @Test
+    @DisplayName("Rook 움직임 예외처리 - 대각선")
+    public void moveRook_Diagonal_exception() {
+        board.initialize();
+        board.removePiece("a7"); //직선에 있는 PAWN 제거
+        board.removePiece("b7");
+
+        Position source = new Position("a8");
+        Position target = new Position("c6");
+        Piece Rook = board.getPiece(source.getRow(), source.getCol());
+
+
+        assertThat(Rook.canMove(source, target, board)).isFalse();
+
+    }
+
+    @Test
+    @DisplayName("Rook 움직임 예외처리 - 중간에 장애물 있는 경우")
+    public void moveRook_obstacle_exception() {
+        board.initialize();
+        board.removePiece("a7"); //직선에 있는 PAWN 제거
+
+        Position source = new Position("a8");
+        Position target = new Position("a1");
+        Piece Rook = board.getPiece(source.getRow(), source.getCol());
+
+
+        assertThat(Rook.canMove(source, target, board)).isFalse();
+
+    }
+
+}


### PR DESCRIPTION
## 구현 내용
* board 클래스에 기물 이동 메서드 구현 
* ChessGame클래스에서 move를 입력받고, 에러가 발생해도 계속 실행할 수 있게 구현
    * Piece 클래스를 추상 클래스로 변경하고 하위 클래스 구현 
* 각 기물의 이동 구현
    * target 좌표가 같은 색 기물이면 이동 불가
    * 이동하는 경로에 기물이 있으면 이동 불가
    * 한 칸 이상 이동하는 기물들은 재귀로 구현

## 고민 사항
* King과 PAWN에서 Direction을 사용하지 않고있는데  Direction을 사용하도록 수정하는것을 고민 중이다.
*  Piece를 추상 클래스로 구현했는데 인터페이스로 구현할수도 있을 것 같다.

## 기타

